### PR TITLE
feat(fuel-prices): add Fuel Price Watch to Transparency [pending real fuel data JSON]

### DIFF
--- a/scripts/generate-search-index.ts
+++ b/scripts/generate-search-index.ts
@@ -99,6 +99,15 @@ async function generateSearchIndex() {
       category: 'Transparency',
       type: 'page',
     },
+    {
+      title: 'Fuel Price Watch',
+      description: 'Weekly DOE retail fuel prices in Bacolod City',
+      content:
+        'fuel prices gas gasoline diesel kerosene petroleum DOE pump price weekly Bacolod RON 91 95 97',
+      url: '/transparency',
+      category: 'Transparency',
+      type: 'page',
+    },
   ];
 
   for (const page of pages) {

--- a/scripts/import-fuel-prices.py
+++ b/scripts/import-fuel-prices.py
@@ -82,6 +82,42 @@ def main(xlsx_path: str) -> None:
                 for (s, mn, mx) in sorted(entries, key=lambda e: e[0])
             ],
         })
+    all_dates = sorted({s['date'] for s in snapshots})
+    all_types = [t for t in PRODUCT_ORDER if any(s['fuelType'] == t for s in snapshots)]
+
+    # Carry-forward: for each fuel type, fill missing weeks (within its reporting
+    # window) with the prior week's values, marked stale so the UI can flag them.
+    # Only real (non-stale) snapshots seed the carry-forward chain, so re-running
+    # the script on already-processed data cannot propagate stale staleSince refs.
+    carried = []
+    for fuel_type in all_types:
+        fuel_snapshots = {
+            s['date']: s
+            for s in snapshots
+            if s['fuelType'] == fuel_type and not s.get('stale')
+        }
+        if not fuel_snapshots:
+            continue
+        real_dates = sorted(fuel_snapshots.keys())
+        first_seen = real_dates[0]
+        last_known = None
+        for week in all_dates:
+            if week < first_seen:
+                continue
+            if week in fuel_snapshots:
+                last_known = fuel_snapshots[week]
+                continue
+            if last_known is None:
+                continue
+            carried.append({
+                **last_known,
+                'id': f'fp-{week}-{slug(fuel_type)}',
+                'date': week,
+                'stale': True,
+                'staleSince': last_known['date'],
+            })
+    snapshots.extend(carried)
+
     snapshots.sort(
         key=lambda s: (
             -int(s['date'].replace('-', '')),
@@ -90,7 +126,6 @@ def main(xlsx_path: str) -> None:
     )
 
     all_dates = sorted({s['date'] for s in snapshots}, reverse=True)
-    all_types = [t for t in PRODUCT_ORDER if any(s['fuelType'] == t for s in snapshots)]
     latest_week = all_dates[0]
     stations_in_latest = set()
     for s in snapshots:

--- a/scripts/import-fuel-prices.py
+++ b/scripts/import-fuel-prices.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Convert a DOE Bacolod fuel-prices XLSX export (from @Shiro_Oni's Power BI)
+into src/data/transparency/fuel-prices.json.
+
+Usage:
+    python3 scripts/import-fuel-prices.py <path-to-xlsx>
+
+The XLSX must have a sheet named `f_FuelPrices` with columns:
+    ReportDate | PRODUCT | Station | Price | MinPrice | MaxPrice
+
+DOE updates prices weekly; drop a fresh XLSX in and re-run.
+
+Requires: pip install openpyxl
+"""
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean
+
+import openpyxl
+
+PRODUCT_MAP = {
+    'RON 91': 'Gasoline RON 91',
+    'RON 95': 'Gasoline RON 95',
+    'RON 97': 'Gasoline RON 97',
+    'RON 100': 'Gasoline RON 100',
+    'DIESEL': 'Diesel',
+    'DIESEL PLUS': 'Diesel Plus',
+    'KEROSENE': 'Kerosene',
+}
+PRODUCT_ORDER = list(PRODUCT_MAP.values())
+OUTPUT_PATH = Path('src/data/transparency/fuel-prices.json')
+
+
+def slug(s: str) -> str:
+    return (
+        s.lower()
+        .replace('gasoline ron ', 'gas')
+        .replace('diesel plus', 'dslplus')
+        .replace('diesel', 'dsl')
+        .replace('kerosene', 'krs')
+        .replace(' ', '')
+    )
+
+
+def main(xlsx_path: str) -> None:
+    wb = openpyxl.load_workbook(xlsx_path, data_only=True)
+    ws = wb['f_FuelPrices']
+
+    bucket = defaultdict(list)
+    for i, row in enumerate(ws.iter_rows(values_only=True)):
+        if i == 0:
+            continue
+        date, product, station, _price, mn, mx = row
+        if date is None or product is None or mn is None or mx is None:
+            continue
+        fuel_type = PRODUCT_MAP.get(product)
+        if not fuel_type:
+            continue
+        date_iso = (
+            date.date().isoformat() if hasattr(date, 'date') else str(date)[:10]
+        )
+        bucket[(date_iso, fuel_type)].append((station, float(mn), float(mx)))
+
+    snapshots = []
+    for (date_iso, fuel_type), entries in bucket.items():
+        mins = [e[1] for e in entries]
+        maxs = [e[2] for e in entries]
+        mids = [(e[1] + e[2]) / 2 for e in entries]
+        snapshots.append({
+            'id': f'fp-{date_iso}-{slug(fuel_type)}',
+            'date': date_iso,
+            'fuelType': fuel_type,
+            'priceMin': round(min(mins), 2),
+            'priceAvg': round(mean(mids), 2),
+            'priceMax': round(max(maxs), 2),
+            'stationCount': len(entries),
+            'byStation': [
+                {'station': s, 'priceMin': round(mn, 2), 'priceMax': round(mx, 2)}
+                for (s, mn, mx) in sorted(entries, key=lambda e: e[0])
+            ],
+        })
+    snapshots.sort(
+        key=lambda s: (
+            -int(s['date'].replace('-', '')),
+            PRODUCT_ORDER.index(s['fuelType']),
+        ),
+    )
+
+    all_dates = sorted({s['date'] for s in snapshots}, reverse=True)
+    all_types = [t for t in PRODUCT_ORDER if any(s['fuelType'] == t for s in snapshots)]
+    latest_week = all_dates[0]
+    stations_in_latest = set()
+    for s in snapshots:
+        if s['date'] == latest_week:
+            for b in s['byStation']:
+                stations_in_latest.add(b['station'])
+
+    out = {
+        'placeholder': False,
+        'snapshots': snapshots,
+        'filters': {
+            'fuelTypes': all_types,
+            'weeks': all_dates,
+            'brands': sorted(stations_in_latest),
+        },
+        'stats': {
+            'latestWeek': latest_week,
+            'weeksTracked': len(all_dates),
+            'fuelTypes': len(all_types),
+            'stationsSurveyed': len(stations_in_latest),
+        },
+        'source': 'DOE Oil Industry Management Bureau',
+        'sourceUrl': 'https://www.doe.gov.ph/oil-monitor',
+        'contributor': 'Shiro_Oni',
+        'lastUpdated': latest_week,
+    }
+
+    OUTPUT_PATH.write_text(json.dumps(out, indent=2))
+    print(
+        f'Wrote {len(snapshots)} snapshots across {len(all_dates)} weeks '
+        f'({all_dates[-1]} to {all_dates[0]}), {len(all_types)} fuel types, '
+        f'{len(stations_in_latest)} brands',
+    )
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python3 scripts/import-fuel-prices.py <path-to-xlsx>')
+        sys.exit(1)
+    main(sys.argv[1])

--- a/src/components/transparency/FuelPricesChart.tsx
+++ b/src/components/transparency/FuelPricesChart.tsx
@@ -1,0 +1,173 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import fuelData from '../../data/transparency/fuel-prices.json';
+
+const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#A855F7'];
+
+type Snapshot = (typeof fuelData.snapshots)[number];
+
+export default function FuelPricesChart() {
+  const fuelTypes = fuelData.filters.fuelTypes;
+  const weeks = [...fuelData.filters.weeks].reverse();
+
+  const trendData = weeks.map((week) => {
+    const row: Record<string, number | string> = { week: week.slice(5) };
+    for (const type of fuelTypes) {
+      const snap = fuelData.snapshots.find(
+        (s: Snapshot) => s.date === week && s.fuelType === type,
+      );
+      if (snap) row[type] = snap.priceAvg;
+    }
+    return row;
+  });
+
+  const latestWeek = fuelData.stats.latestWeek;
+  const latestBreakdown = fuelTypes.map((type) => {
+    const snap = fuelData.snapshots.find(
+      (s: Snapshot) => s.date === latestWeek && s.fuelType === type,
+    );
+    return {
+      name: type.replace('Gasoline RON ', 'RON '),
+      min: snap?.priceMin ?? 0,
+      avg: snap?.priceAvg ?? 0,
+      max: snap?.priceMax ?? 0,
+    };
+  });
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+      <div className="bg-white p-5 rounded-xl border border-gray-200 shadow-sm">
+        <h3 className="text-sm font-bold text-gray-800 mb-1">Price trend</h3>
+        <p className="text-xs text-gray-500 mb-4">
+          Weekly average by fuel type (₱/L)
+        </p>
+        <div className="h-[250px] w-full text-xs">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={trendData}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                stroke="#f3f4f6"
+              />
+              <XAxis
+                dataKey="week"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: '#6b7280' }}
+                dy={8}
+              />
+              <YAxis
+                domain={['dataMin - 1', 'dataMax + 1']}
+                tickFormatter={(value: number) => `₱${value.toFixed(0)}`}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: '#6b7280' }}
+                width={40}
+              />
+              <Tooltip
+                contentStyle={{
+                  borderRadius: '8px',
+                  border: 'none',
+                  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                  fontSize: '12px',
+                }}
+                formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
+              />
+              <Legend
+                verticalAlign="bottom"
+                height={36}
+                iconType="circle"
+                wrapperStyle={{ fontSize: '11px' }}
+              />
+              {fuelTypes.map((type, index) => (
+                <Line
+                  key={type}
+                  type="monotone"
+                  dataKey={type}
+                  stroke={COLORS[index % COLORS.length]}
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className="bg-white p-5 rounded-xl border border-gray-200 shadow-sm">
+        <h3 className="text-sm font-bold text-gray-800 mb-1">Latest week</h3>
+        <p className="text-xs text-gray-500 mb-4">
+          Min, average, and max per fuel type — week of {latestWeek}
+        </p>
+        <div className="h-[250px] w-full text-xs">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={latestBreakdown}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                stroke="#f3f4f6"
+              />
+              <XAxis
+                dataKey="name"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: '#6b7280', fontSize: 10 }}
+                dy={8}
+              />
+              <YAxis
+                tickFormatter={(value: number) => `₱${value.toFixed(0)}`}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: '#6b7280' }}
+                width={40}
+              />
+              <Tooltip
+                cursor={{ fill: '#f9fafb' }}
+                contentStyle={{
+                  borderRadius: '8px',
+                  border: 'none',
+                  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                  fontSize: '12px',
+                }}
+                formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
+              />
+              <Legend
+                verticalAlign="bottom"
+                height={36}
+                iconType="circle"
+                wrapperStyle={{ fontSize: '11px' }}
+              />
+              <Bar dataKey="min" radius={[4, 4, 0, 0]}>
+                {latestBreakdown.map((entry) => (
+                  <Cell key={`min-${entry.name}`} fill={COLORS[0]} />
+                ))}
+              </Bar>
+              <Bar dataKey="avg" radius={[4, 4, 0, 0]}>
+                {latestBreakdown.map((entry) => (
+                  <Cell key={`avg-${entry.name}`} fill={COLORS[1]} />
+                ))}
+              </Bar>
+              <Bar dataKey="max" radius={[4, 4, 0, 0]}>
+                {latestBreakdown.map((entry) => (
+                  <Cell key={`max-${entry.name}`} fill={COLORS[3]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/transparency/FuelPricesChart.tsx
+++ b/src/components/transparency/FuelPricesChart.tsx
@@ -116,7 +116,10 @@ export default function FuelPricesChart() {
                 fontSize: '12px',
               }}
               labelStyle={{ fontWeight: 600, marginBottom: 2 }}
-              formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
+              formatter={(value, name) => [
+                `₱${Number(value ?? 0).toFixed(2)}`,
+                String(name),
+              ]}
             />
             <Legend
               verticalAlign="bottom"
@@ -137,6 +140,7 @@ export default function FuelPricesChart() {
                   strokeWidth={2}
                   fill={`url(#${id})`}
                   fillOpacity={1}
+                  dot={false}
                   activeDot={{ r: 4, strokeWidth: 2, stroke: '#fff' }}
                 />
               );

--- a/src/components/transparency/FuelPricesChart.tsx
+++ b/src/components/transparency/FuelPricesChart.tsx
@@ -1,8 +1,9 @@
 import {
+  Area,
   CartesianGrid,
+  ComposedChart,
   Legend,
   Line,
-  LineChart,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -10,24 +11,46 @@ import {
 } from 'recharts';
 import fuelData from '../../data/transparency/fuel-prices.json';
 
-const COLORS = [
-  '#0088FE',
-  '#00C49F',
-  '#FFBB28',
-  '#FF8042',
-  '#A855F7',
-  '#EC4899',
-  '#14B8A6',
-];
+export const FUEL_COLORS: Record<string, string> = {
+  'Gasoline RON 91': '#0ea5e9',
+  'Gasoline RON 95': '#10b981',
+  'Gasoline RON 97': '#f59e0b',
+  'Gasoline RON 100': '#ef4444',
+  Diesel: '#6366f1',
+  'Diesel Plus': '#a855f7',
+  Kerosene: '#ec4899',
+};
 
 type Snapshot = (typeof fuelData.snapshots)[number];
+
+const monthNames = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+const formatWeekLabel = (isoDate: string) => {
+  const [, m, d] = isoDate.split('-');
+  return `${monthNames[Number(m) - 1]} ${Number(d)}`;
+};
 
 export default function FuelPricesChart() {
   const fuelTypes = fuelData.filters.fuelTypes;
   const weeks = [...fuelData.filters.weeks].reverse();
 
   const trendData = weeks.map((week) => {
-    const row: Record<string, number | string> = { week: week.slice(5) };
+    const row: Record<string, number | string> = {
+      week,
+      label: formatWeekLabel(week),
+    };
     for (const type of fuelTypes) {
       const snap = fuelData.snapshots.find(
         (s: Snapshot) => s.date === week && s.fuelType === type,
@@ -38,24 +61,45 @@ export default function FuelPricesChart() {
   });
 
   return (
-    <div className="bg-white p-4 rounded-lg border border-gray-200">
-      <div className="h-[260px] w-full text-xs">
+    <div className="relative bg-gradient-to-br from-white via-white to-primary-50/30 p-4 sm:p-5 rounded-xl border border-gray-200 shadow-sm">
+      <div className="h-[260px] sm:h-[320px] w-full text-xs">
         <ResponsiveContainer width="100%" height="100%">
-          <LineChart
+          <ComposedChart
             data={trendData}
             margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
           >
+            <defs>
+              {fuelTypes.map((type) => {
+                const id = `grad-${type.replace(/\s+/g, '-')}`;
+                return (
+                  <linearGradient key={id} id={id} x1="0" y1="0" x2="0" y2="1">
+                    <stop
+                      offset="0%"
+                      stopColor={FUEL_COLORS[type] ?? '#6b7280'}
+                      stopOpacity={0.18}
+                    />
+                    <stop
+                      offset="100%"
+                      stopColor={FUEL_COLORS[type] ?? '#6b7280'}
+                      stopOpacity={0}
+                    />
+                  </linearGradient>
+                );
+              })}
+            </defs>
             <CartesianGrid
               strokeDasharray="3 3"
               vertical={false}
-              stroke="#f3f4f6"
+              stroke="#e5e7eb"
             />
             <XAxis
-              dataKey="week"
+              dataKey="label"
               axisLine={false}
               tickLine={false}
               tick={{ fill: '#6b7280', fontSize: 11 }}
               dy={6}
+              interval="preserveStartEnd"
+              minTickGap={24}
             />
             <YAxis
               domain={['dataMin - 2', 'dataMax + 2']}
@@ -67,11 +111,12 @@ export default function FuelPricesChart() {
             />
             <Tooltip
               contentStyle={{
-                borderRadius: '8px',
-                border: 'none',
-                boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                borderRadius: '10px',
+                border: '1px solid #e5e7eb',
+                boxShadow: '0 8px 24px -8px rgb(0 0 0 / 0.15)',
                 fontSize: '12px',
               }}
+              labelStyle={{ fontWeight: 600, marginBottom: 2 }}
               formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
             />
             <Legend
@@ -79,20 +124,34 @@ export default function FuelPricesChart() {
               height={32}
               iconType="circle"
               iconSize={8}
-              wrapperStyle={{ fontSize: '11px' }}
+              wrapperStyle={{ fontSize: '11px', paddingTop: 4 }}
             />
-            {fuelTypes.map((type, index) => (
+            {fuelTypes.map((type) => {
+              const id = `grad-${type.replace(/\s+/g, '-')}`;
+              return (
+                <Area
+                  key={`area-${type}`}
+                  type="monotone"
+                  dataKey={type}
+                  stroke="none"
+                  fill={`url(#${id})`}
+                  isAnimationActive={false}
+                  legendType="none"
+                />
+              );
+            })}
+            {fuelTypes.map((type) => (
               <Line
                 key={type}
                 type="monotone"
                 dataKey={type}
-                stroke={COLORS[index % COLORS.length]}
+                stroke={FUEL_COLORS[type] ?? '#6b7280'}
                 strokeWidth={2}
                 dot={false}
-                activeDot={{ r: 4 }}
+                activeDot={{ r: 4, strokeWidth: 2, stroke: '#fff' }}
               />
             ))}
-          </LineChart>
+          </ComposedChart>
         </ResponsiveContainer>
       </div>
     </div>

--- a/src/components/transparency/FuelPricesChart.tsx
+++ b/src/components/transparency/FuelPricesChart.tsx
@@ -1,9 +1,8 @@
 import {
   Area,
+  AreaChart,
   CartesianGrid,
-  ComposedChart,
   Legend,
-  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -64,7 +63,7 @@ export default function FuelPricesChart() {
     <div className="relative bg-gradient-to-br from-white via-white to-primary-50/30 p-4 sm:p-5 rounded-xl border border-gray-200 shadow-sm">
       <div className="h-[260px] sm:h-[320px] w-full text-xs">
         <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart
+          <AreaChart
             data={trendData}
             margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
           >
@@ -76,7 +75,7 @@ export default function FuelPricesChart() {
                     <stop
                       offset="0%"
                       stopColor={FUEL_COLORS[type] ?? '#6b7280'}
-                      stopOpacity={0.18}
+                      stopOpacity={0.2}
                     />
                     <stop
                       offset="100%"
@@ -127,31 +126,22 @@ export default function FuelPricesChart() {
               wrapperStyle={{ fontSize: '11px', paddingTop: 4 }}
             />
             {fuelTypes.map((type) => {
+              const color = FUEL_COLORS[type] ?? '#6b7280';
               const id = `grad-${type.replace(/\s+/g, '-')}`;
               return (
                 <Area
-                  key={`area-${type}`}
+                  key={type}
                   type="monotone"
                   dataKey={type}
-                  stroke="none"
+                  stroke={color}
+                  strokeWidth={2}
                   fill={`url(#${id})`}
-                  isAnimationActive={false}
-                  legendType="none"
+                  fillOpacity={1}
+                  activeDot={{ r: 4, strokeWidth: 2, stroke: '#fff' }}
                 />
               );
             })}
-            {fuelTypes.map((type) => (
-              <Line
-                key={type}
-                type="monotone"
-                dataKey={type}
-                stroke={FUEL_COLORS[type] ?? '#6b7280'}
-                strokeWidth={2}
-                dot={false}
-                activeDot={{ r: 4, strokeWidth: 2, stroke: '#fff' }}
-              />
-            ))}
-          </ComposedChart>
+          </AreaChart>
         </ResponsiveContainer>
       </div>
     </div>

--- a/src/components/transparency/FuelPricesChart.tsx
+++ b/src/components/transparency/FuelPricesChart.tsx
@@ -1,8 +1,5 @@
 import {
-  Bar,
-  BarChart,
   CartesianGrid,
-  Cell,
   Legend,
   Line,
   LineChart,
@@ -13,7 +10,15 @@ import {
 } from 'recharts';
 import fuelData from '../../data/transparency/fuel-prices.json';
 
-const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#A855F7'];
+const COLORS = [
+  '#0088FE',
+  '#00C49F',
+  '#FFBB28',
+  '#FF8042',
+  '#A855F7',
+  '#EC4899',
+  '#14B8A6',
+];
 
 type Snapshot = (typeof fuelData.snapshots)[number];
 
@@ -32,141 +37,63 @@ export default function FuelPricesChart() {
     return row;
   });
 
-  const latestWeek = fuelData.stats.latestWeek;
-  const latestBreakdown = fuelTypes.map((type) => {
-    const snap = fuelData.snapshots.find(
-      (s: Snapshot) => s.date === latestWeek && s.fuelType === type,
-    );
-    return {
-      name: type.replace('Gasoline RON ', 'RON '),
-      min: snap?.priceMin ?? 0,
-      avg: snap?.priceAvg ?? 0,
-      max: snap?.priceMax ?? 0,
-    };
-  });
-
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
-      <div className="bg-white p-5 rounded-xl border border-gray-200 shadow-sm">
-        <h3 className="text-sm font-bold text-gray-800 mb-1">Price trend</h3>
-        <p className="text-xs text-gray-500 mb-4">
-          Weekly average by fuel type (₱/L)
-        </p>
-        <div className="h-[250px] w-full text-xs">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={trendData}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke="#f3f4f6"
+    <div className="bg-white p-4 rounded-lg border border-gray-200">
+      <div className="h-[260px] w-full text-xs">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={trendData}
+            margin={{ top: 8, right: 12, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              vertical={false}
+              stroke="#f3f4f6"
+            />
+            <XAxis
+              dataKey="week"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: '#6b7280', fontSize: 11 }}
+              dy={6}
+            />
+            <YAxis
+              domain={['dataMin - 2', 'dataMax + 2']}
+              tickFormatter={(value: number) => `₱${value.toFixed(0)}`}
+              axisLine={false}
+              tickLine={false}
+              tick={{ fill: '#6b7280', fontSize: 11 }}
+              width={44}
+            />
+            <Tooltip
+              contentStyle={{
+                borderRadius: '8px',
+                border: 'none',
+                boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+                fontSize: '12px',
+              }}
+              formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
+            />
+            <Legend
+              verticalAlign="bottom"
+              height={32}
+              iconType="circle"
+              iconSize={8}
+              wrapperStyle={{ fontSize: '11px' }}
+            />
+            {fuelTypes.map((type, index) => (
+              <Line
+                key={type}
+                type="monotone"
+                dataKey={type}
+                stroke={COLORS[index % COLORS.length]}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
               />
-              <XAxis
-                dataKey="week"
-                axisLine={false}
-                tickLine={false}
-                tick={{ fill: '#6b7280' }}
-                dy={8}
-              />
-              <YAxis
-                domain={['dataMin - 1', 'dataMax + 1']}
-                tickFormatter={(value: number) => `₱${value.toFixed(0)}`}
-                axisLine={false}
-                tickLine={false}
-                tick={{ fill: '#6b7280' }}
-                width={40}
-              />
-              <Tooltip
-                contentStyle={{
-                  borderRadius: '8px',
-                  border: 'none',
-                  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
-                  fontSize: '12px',
-                }}
-                formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
-              />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                iconType="circle"
-                wrapperStyle={{ fontSize: '11px' }}
-              />
-              {fuelTypes.map((type, index) => (
-                <Line
-                  key={type}
-                  type="monotone"
-                  dataKey={type}
-                  stroke={COLORS[index % COLORS.length]}
-                  strokeWidth={2}
-                  dot={{ r: 3 }}
-                  activeDot={{ r: 5 }}
-                />
-              ))}
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-
-      <div className="bg-white p-5 rounded-xl border border-gray-200 shadow-sm">
-        <h3 className="text-sm font-bold text-gray-800 mb-1">Latest week</h3>
-        <p className="text-xs text-gray-500 mb-4">
-          Min, average, and max per fuel type — week of {latestWeek}
-        </p>
-        <div className="h-[250px] w-full text-xs">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={latestBreakdown}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke="#f3f4f6"
-              />
-              <XAxis
-                dataKey="name"
-                axisLine={false}
-                tickLine={false}
-                tick={{ fill: '#6b7280', fontSize: 10 }}
-                dy={8}
-              />
-              <YAxis
-                tickFormatter={(value: number) => `₱${value.toFixed(0)}`}
-                axisLine={false}
-                tickLine={false}
-                tick={{ fill: '#6b7280' }}
-                width={40}
-              />
-              <Tooltip
-                cursor={{ fill: '#f9fafb' }}
-                contentStyle={{
-                  borderRadius: '8px',
-                  border: 'none',
-                  boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
-                  fontSize: '12px',
-                }}
-                formatter={(value) => [`₱${Number(value ?? 0).toFixed(2)}`, '']}
-              />
-              <Legend
-                verticalAlign="bottom"
-                height={36}
-                iconType="circle"
-                wrapperStyle={{ fontSize: '11px' }}
-              />
-              <Bar dataKey="min" radius={[4, 4, 0, 0]}>
-                {latestBreakdown.map((entry) => (
-                  <Cell key={`min-${entry.name}`} fill={COLORS[0]} />
-                ))}
-              </Bar>
-              <Bar dataKey="avg" radius={[4, 4, 0, 0]}>
-                {latestBreakdown.map((entry) => (
-                  <Cell key={`avg-${entry.name}`} fill={COLORS[1]} />
-                ))}
-              </Bar>
-              <Bar dataKey="max" radius={[4, 4, 0, 0]}>
-                {latestBreakdown.map((entry) => (
-                  <Cell key={`max-${entry.name}`} fill={COLORS[3]} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -1,0 +1,283 @@
+import { ChevronDown, ExternalLink, Info, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import fuelData from '../../data/transparency/fuel-prices.json';
+import FuelPricesChart from './FuelPricesChart';
+
+type Snapshot = (typeof fuelData.snapshots)[number];
+
+const peso = (v: number) => `₱${v.toFixed(2)}`;
+
+export default function FuelPricesSection() {
+  const [search, setSearch] = useState('');
+  const [fuelFilter, setFuelFilter] = useState('');
+  const [weekFilter, setWeekFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    return fuelData.snapshots.filter((s: Snapshot) => {
+      const matchSearch =
+        !search || s.fuelType.toLowerCase().includes(search.toLowerCase());
+      const matchFuel = !fuelFilter || s.fuelType === fuelFilter;
+      const matchWeek = !weekFilter || s.date === weekFilter;
+      return matchSearch && matchFuel && matchWeek;
+    });
+  }, [search, fuelFilter, weekFilter]);
+
+  const headline = useMemo(() => {
+    const latest = fuelData.snapshots.filter(
+      (s) => s.date === fuelData.stats.latestWeek,
+    );
+    if (latest.length === 0) return null;
+
+    const prior = fuelData.snapshots.filter(
+      (s) => s.date === fuelData.filters.weeks[1],
+    );
+
+    const sortedByPrice = [...latest].sort((a, b) => a.priceAvg - b.priceAvg);
+    const cheapest = sortedByPrice[0];
+    const priciest = sortedByPrice[sortedByPrice.length - 1];
+
+    const latestAvg =
+      latest.reduce((sum, s) => sum + s.priceAvg, 0) / latest.length;
+    const priorAvg =
+      prior.length > 0
+        ? prior.reduce((sum, s) => sum + s.priceAvg, 0) / prior.length
+        : latestAvg;
+    const weeklyChange = latestAvg - priorAvg;
+
+    return { cheapest, priciest, weeklyChange };
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      {fuelData.placeholder && (
+        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
+          <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
+          <p>
+            Showing placeholder figures while we finalize the DOE data feed with{' '}
+            <span className="font-medium">@Shiro_Oni</span>. Numbers below are
+            illustrative and should not be used for purchasing decisions.
+          </p>
+        </div>
+      )}
+
+      {headline && (
+        <div className="grid grid-cols-3 gap-2 sm:gap-3 text-center">
+          <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
+            <p className="text-xs text-primary-600">Cheapest</p>
+            <p className="text-lg sm:text-xl font-bold text-primary-700">
+              {peso(headline.cheapest.priceAvg)}
+            </p>
+            <p className="text-[10px] text-primary-600/80 truncate">
+              {headline.cheapest.fuelType}
+            </p>
+          </div>
+          <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
+            <p className="text-xs text-primary-600">Most expensive</p>
+            <p className="text-lg sm:text-xl font-bold text-primary-700">
+              {peso(headline.priciest.priceAvg)}
+            </p>
+            <p className="text-[10px] text-primary-600/80 truncate">
+              {headline.priciest.fuelType}
+            </p>
+          </div>
+          <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
+            <p className="text-xs text-primary-600">Weekly change</p>
+            <p
+              className={`text-lg sm:text-xl font-bold ${
+                headline.weeklyChange > 0
+                  ? 'text-rose-600'
+                  : headline.weeklyChange < 0
+                    ? 'text-emerald-600'
+                    : 'text-primary-700'
+              }`}
+            >
+              <span aria-hidden="true">
+                {headline.weeklyChange > 0
+                  ? '▲'
+                  : headline.weeklyChange < 0
+                    ? '▼'
+                    : '■'}
+              </span>
+              <span className="sr-only">
+                {headline.weeklyChange > 0
+                  ? 'Increased by '
+                  : headline.weeklyChange < 0
+                    ? 'Decreased by '
+                    : 'Unchanged at '}
+              </span>{' '}
+              ₱{Math.abs(headline.weeklyChange).toFixed(2)}
+            </p>
+            <p className="text-[10px] text-primary-600/80">vs prior week</p>
+          </div>
+        </div>
+      )}
+
+      <FuelPricesChart />
+
+      <div className="flex flex-col sm:flex-row gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            aria-label="Search fuel type"
+            placeholder="Search fuel type..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+        <div className="relative">
+          <select
+            value={fuelFilter}
+            onChange={(e) => setFuelFilter(e.target.value)}
+            className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="">All fuel types</option>
+            {fuelData.filters.fuelTypes.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+        </div>
+        <div className="relative">
+          <select
+            value={weekFilter}
+            onChange={(e) => setWeekFilter(e.target.value)}
+            className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+          >
+            <option value="">All weeks</option>
+            {fuelData.filters.weeks.map((w) => (
+              <option key={w} value={w}>
+                {w}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+        </div>
+      </div>
+
+      <div className="border border-gray-200 rounded-lg overflow-hidden">
+        <div className="max-h-[400px] overflow-y-auto">
+          <table
+            className="w-full text-sm"
+            aria-label="Weekly fuel price snapshots"
+          >
+            <thead className="bg-gray-50 sticky top-0">
+              <tr>
+                <th
+                  scope="col"
+                  className="text-left py-2 px-3 font-medium text-gray-600"
+                >
+                  Week
+                </th>
+                <th
+                  scope="col"
+                  className="text-left py-2 px-3 font-medium text-gray-600"
+                >
+                  Fuel type
+                </th>
+                <th
+                  scope="col"
+                  className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
+                >
+                  Min
+                </th>
+                <th
+                  scope="col"
+                  className="text-right py-2 px-3 font-medium text-gray-600"
+                >
+                  Avg
+                </th>
+                <th
+                  scope="col"
+                  className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
+                >
+                  Max
+                </th>
+                <th
+                  scope="col"
+                  className="text-right py-2 px-3 font-medium text-gray-600 hidden md:table-cell"
+                >
+                  Stations
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {filtered.map((s) => (
+                <tr key={s.id} className="hover:bg-gray-50">
+                  <td className="py-2 px-3 text-gray-900 whitespace-nowrap">
+                    {s.date}
+                  </td>
+                  <td className="py-2 px-3 text-gray-700">{s.fuelType}</td>
+                  <td className="py-2 px-3 text-right text-gray-700 hidden sm:table-cell whitespace-nowrap">
+                    {peso(s.priceMin)}
+                  </td>
+                  <td className="py-2 px-3 text-right text-gray-900 font-medium whitespace-nowrap">
+                    {peso(s.priceAvg)}
+                  </td>
+                  <td className="py-2 px-3 text-right text-gray-700 hidden sm:table-cell whitespace-nowrap">
+                    {peso(s.priceMax)}
+                  </td>
+                  <td className="py-2 px-3 text-right text-gray-600 hidden md:table-cell">
+                    {s.stationCount}
+                  </td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-gray-500">
+                    No snapshots for this fuel type in the selected range
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 pt-2">
+        <a
+          href={fuelData.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white rounded text-sm hover:bg-primary-700"
+        >
+          DOE Oil Monitor <ExternalLink className="h-3 w-3" />
+        </a>
+        <a
+          href="https://www.doe.gov.ph/doe-oil-price-monitor"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 px-3 py-1.5 border border-primary-600 text-primary-600 rounded text-sm hover:bg-primary-50"
+        >
+          Weekly price bulletins <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+
+      <p className="text-xs text-gray-500 pt-2">
+        Source:{' '}
+        <a
+          href={fuelData.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          {fuelData.source}
+        </a>{' '}
+        • Data contributed by{' '}
+        <span className="font-medium">@{fuelData.contributor}</span> • Report
+        issues:{' '}
+        <a
+          href="https://sumbongsapangulo.ph/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          sumbongsapangulo.ph
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -53,11 +53,29 @@ const monthNames = [
   'November',
   'December',
 ];
-const formatWeekRange = (iso: string) => {
+const monthShort = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+const weekDates = (iso: string) => {
   const [y, m, d] = iso.split('-').map(Number);
   const start = new Date(Date.UTC(y, m - 1, d));
   const end = new Date(start);
   end.setUTCDate(end.getUTCDate() + 6);
+  return { start, end };
+};
+const formatWeekRange = (iso: string) => {
+  const { start, end } = weekDates(iso);
   const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
   const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
   const startMonth = monthNames[start.getUTCMonth()];
@@ -69,6 +87,29 @@ const formatWeekRange = (iso: string) => {
     ? `${end.getUTCDate()}`
     : `${endMonth} ${end.getUTCDate()}`;
   return `${startMonth} ${start.getUTCDate()} – ${endLabel}, ${end.getUTCFullYear()}`;
+};
+const formatWeekRangeShort = (iso: string) => {
+  const { start, end } = weekDates(iso);
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
+  const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
+  const startMonth = monthShort[start.getUTCMonth()];
+  const endMonth = monthShort[end.getUTCMonth()];
+  if (!sameYear) {
+    return `${startMonth} ${start.getUTCDate()} – ${endMonth} ${end.getUTCDate()}`;
+  }
+  return sameMonth
+    ? `${startMonth} ${start.getUTCDate()}–${end.getUTCDate()}`
+    : `${startMonth} ${start.getUTCDate()} – ${endMonth} ${end.getUTCDate()}`;
+};
+const formatDateShort = (iso: string) => {
+  const [y, m, d] = iso.split('-').map(Number);
+  return `${monthShort[m - 1]} ${d}, ${y}`;
+};
+const daysSinceWeekEnd = (iso: string) => {
+  const { end } = weekDates(iso);
+  const now = new Date();
+  const diff = now.getTime() - end.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
 };
 
 function FuelRow({
@@ -195,6 +236,12 @@ export default function FuelPricesSection() {
   const [fuelFilter, setFuelFilter] = useState('');
   const [weekFilter, setWeekFilter] = useState('');
 
+  const latestWeek = fuelData.stats.latestWeek;
+  const weekShort = formatWeekRangeShort(latestWeek);
+  const { end: latestEnd } = weekDates(latestWeek);
+  const daysAgo = daysSinceWeekEnd(latestWeek);
+  const latestEndIso = latestEnd.toISOString().slice(0, 10);
+
   const latestCards = useMemo(() => {
     const latestWeek = fuelData.stats.latestWeek;
     const priorWeek = fuelData.filters.weeks
@@ -226,9 +273,29 @@ export default function FuelPricesSection() {
     <div className="space-y-5 lg:space-y-7">
       {/* Header */}
       <div>
-        <p className="text-[11px] uppercase tracking-[0.12em] text-primary-600 font-semibold">
-          Latest DOE report
-        </p>
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="text-[11px] uppercase tracking-[0.12em] text-primary-600 font-semibold">
+            Latest DOE report
+          </p>
+          {daysAgo >= 0 && (
+            <span
+              className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium tabular-nums ${
+                daysAgo <= 7
+                  ? 'bg-emerald-50 text-emerald-700'
+                  : daysAgo <= 14
+                    ? 'bg-amber-50 text-amber-700'
+                    : 'bg-rose-50 text-rose-700'
+              }`}
+            >
+              reported{' '}
+              {daysAgo <= 0
+                ? 'today'
+                : daysAgo === 1
+                  ? '1 day ago'
+                  : `${daysAgo} days ago`}
+            </span>
+          )}
+        </div>
         <h2 className="mt-0.5 text-xl sm:text-2xl font-bold text-gray-900 tabular-nums">
           {formatWeekRange(fuelData.stats.latestWeek)}
         </h2>
@@ -248,11 +315,18 @@ export default function FuelPricesSection() {
 
       {/* Hero: price trend chart */}
       <div>
-        <div className="flex items-baseline justify-between mb-2">
-          <h3 className="text-sm font-semibold text-gray-900">
-            {fuelData.stats.weeksTracked}-week trend
-          </h3>
-          <p className="text-[11px] text-gray-500">tap legend to toggle</p>
+        <div className="flex items-baseline justify-between gap-3 mb-2">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              {fuelData.stats.weeksTracked}-week trend
+            </h3>
+            <p className="text-[11px] text-gray-500 tabular-nums">
+              through {formatDateShort(latestEndIso)}
+            </p>
+          </div>
+          <p className="text-[11px] text-gray-500 flex-shrink-0">
+            tap legend to toggle
+          </p>
         </div>
         <FuelPricesChart />
       </div>
@@ -260,9 +334,14 @@ export default function FuelPricesSection() {
       {/* Cheapest in latest report — flat list */}
       <div>
         <div className="flex items-baseline justify-between gap-3 mb-2">
-          <h3 className="text-sm font-semibold text-gray-900">
-            Cheapest by fuel type
-          </h3>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              Cheapest by fuel type
+            </h3>
+            <p className="text-[11px] text-gray-500 tabular-nums">
+              as of {weekShort}
+            </p>
+          </div>
           <p className="text-[11px] text-gray-500 flex-shrink-0">
             tap a row for all brands
           </p>
@@ -459,9 +538,9 @@ export default function FuelPricesSection() {
         >
           {fuelData.source}
         </a>{' '}
-        · DOE publishes updated prices weekly · Data contributed by{' '}
-        <span className="font-medium">@{fuelData.contributor}</span> · Last
-        updated <span className="tabular-nums">{fuelData.lastUpdated}</span> ·
+        · Updated weekly · Data contributed by{' '}
+        <span className="font-medium">@{fuelData.contributor}</span> · Covering{' '}
+        <span className="tabular-nums">{formatWeekRange(latestWeek)}</span> ·
         Report issues:{' '}
         <a
           href="https://sumbongsapangulo.ph/"

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -4,8 +4,21 @@ import fuelData from '../../data/transparency/fuel-prices.json';
 import FuelPricesChart from './FuelPricesChart';
 
 type Snapshot = (typeof fuelData.snapshots)[number];
+type BrandPrice = { station: string; priceMin: number; priceMax: number };
 
 const peso = (v: number) => `₱${v.toFixed(2)}`;
+const priceRange = (p: { priceMin: number; priceMax: number }) =>
+  p.priceMin === p.priceMax
+    ? peso(p.priceMin)
+    : `${peso(p.priceMin)} – ${peso(p.priceMax)}`;
+
+const prettyBrand = (s: string) =>
+  s === 'INDEPENDENT'
+    ? 'Independent'
+    : s
+        .split(' ')
+        .map((w) => w[0] + w.slice(1).toLowerCase())
+        .join(' ');
 
 export default function FuelPricesSection() {
   const [search, setSearch] = useState('');
@@ -40,15 +53,48 @@ export default function FuelPricesSection() {
     const cheapest = sortedByPrice[0];
     const priciest = sortedByPrice[sortedByPrice.length - 1];
 
-    const latestAvg =
-      latest.reduce((sum, s) => sum + s.priceAvg, 0) / latest.length;
-    const priorAvg =
-      prior.length > 0
-        ? prior.reduce((sum, s) => sum + s.priceAvg, 0) / prior.length
-        : latestAvg;
-    const weeklyChange = latestAvg - priorAvg;
+    const sharedTypes = new Set(
+      latest
+        .map((s) => s.fuelType)
+        .filter((t) => prior.some((p) => p.fuelType === t)),
+    );
+    const latestShared = latest.filter((s) => sharedTypes.has(s.fuelType));
+    const priorShared = prior.filter((s) => sharedTypes.has(s.fuelType));
+    const weeklyChange =
+      priorShared.length > 0
+        ? latestShared.reduce((sum, s) => sum + s.priceAvg, 0) /
+            latestShared.length -
+          priorShared.reduce((sum, s) => sum + s.priceAvg, 0) /
+            priorShared.length
+        : 0;
 
     return { cheapest, priciest, weeklyChange };
+  }, []);
+
+  const latestByBrand = useMemo(() => {
+    const latest = fuelData.snapshots.filter(
+      (s) => s.date === fuelData.stats.latestWeek,
+    );
+    const fuelTypes = latest.map((s) => s.fuelType);
+    const brandSet = new Set<string>();
+    const matrix: Record<string, Record<string, BrandPrice>> = {};
+    for (const snap of latest) {
+      for (const b of snap.byStation as BrandPrice[]) {
+        brandSet.add(b.station);
+        if (!matrix[b.station]) matrix[b.station] = {};
+        matrix[b.station][snap.fuelType] = b;
+      }
+    }
+    const BRAND_PRIORITY = ['SHELL', 'PETRON', 'CALTEX', 'TOTAL', 'SEAOIL'];
+    const brands = [...brandSet].sort((a, b) => {
+      const ai = BRAND_PRIORITY.indexOf(a);
+      const bi = BRAND_PRIORITY.indexOf(b);
+      if (ai !== -1 && bi !== -1) return ai - bi;
+      if (ai !== -1) return -1;
+      if (bi !== -1) return 1;
+      return a.localeCompare(b);
+    });
+    return { brands, fuelTypes, matrix };
   }, []);
 
   return (
@@ -116,7 +162,78 @@ export default function FuelPricesSection() {
         </div>
       )}
 
+      <div className="flex items-start gap-2 bg-primary-50 border border-primary-100 rounded-lg p-3 text-xs text-primary-800">
+        <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
+        <p>
+          <span className="font-medium">Fuel grade guide:</span> RON is the
+          octane rating. <span className="font-medium">RON 91</span> = regular
+          unleaded, <span className="font-medium">RON 95</span> = premium,{' '}
+          <span className="font-medium">RON 97 / 100</span> = super premium.{' '}
+          <span className="font-medium">Diesel Plus</span> is premium diesel.
+        </p>
+      </div>
+
       {fuelData.snapshots.length > 0 && <FuelPricesChart />}
+
+      {latestByBrand.brands.length > 0 && (
+        <div className="border border-gray-200 rounded-lg overflow-hidden">
+          <div className="bg-gray-50 px-3 py-2 border-b border-gray-200">
+            <h3 className="text-sm font-semibold text-gray-900">
+              Latest week by brand
+            </h3>
+            <p className="text-xs text-gray-500">
+              Price range per brand for the week of {fuelData.stats.latestWeek}.
+              Source: DOE survey.
+            </p>
+          </div>
+          <div className="overflow-x-auto">
+            <table
+              className="w-full text-sm"
+              aria-label="Latest week fuel prices by brand"
+            >
+              <thead className="bg-gray-50">
+                <tr>
+                  <th
+                    scope="col"
+                    className="text-left py-2 px-3 font-medium text-gray-600 whitespace-nowrap"
+                  >
+                    Brand
+                  </th>
+                  {latestByBrand.fuelTypes.map((t) => (
+                    <th
+                      key={t}
+                      scope="col"
+                      className="text-right py-2 px-3 font-medium text-gray-600 whitespace-nowrap"
+                    >
+                      {t.replace('Gasoline ', '')}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {latestByBrand.brands.map((brand) => (
+                  <tr key={brand} className="hover:bg-gray-50">
+                    <td className="py-2 px-3 font-medium text-gray-900 whitespace-nowrap">
+                      {prettyBrand(brand)}
+                    </td>
+                    {latestByBrand.fuelTypes.map((t) => {
+                      const cell = latestByBrand.matrix[brand]?.[t];
+                      return (
+                        <td
+                          key={t}
+                          className="py-2 px-3 text-right text-gray-700 whitespace-nowrap"
+                        >
+                          {cell ? priceRange(cell) : '—'}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="relative flex-1">
@@ -264,9 +381,9 @@ export default function FuelPricesSection() {
         >
           {fuelData.source}
         </a>{' '}
-        • Data contributed by{' '}
-        <span className="font-medium">@{fuelData.contributor}</span> • Report
-        issues:{' '}
+        • DOE publishes updated prices weekly • Data contributed by{' '}
+        <span className="font-medium">@{fuelData.contributor}</span> • Last
+        updated {fuelData.lastUpdated} • Report issues:{' '}
         <a
           href="https://sumbongsapangulo.ph/"
           target="_blank"

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -53,9 +53,17 @@ const monthNames = [
   'November',
   'December',
 ];
-const formatLongDate = (iso: string) => {
-  const [y, m, d] = iso.split('-');
-  return `${monthNames[Number(m) - 1]} ${Number(d)}, ${y}`;
+const formatWeekRange = (iso: string) => {
+  const [y, m, d] = iso.split('-').map(Number);
+  const start = new Date(Date.UTC(y, m - 1, d));
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 6);
+  const sameMonth = start.getUTCMonth() === end.getUTCMonth();
+  const startLabel = `${monthNames[start.getUTCMonth()]} ${start.getUTCDate()}`;
+  const endLabel = sameMonth
+    ? `${end.getUTCDate()}`
+    : `${monthNames[end.getUTCMonth()]} ${end.getUTCDate()}`;
+  return `${startLabel} – ${endLabel}, ${end.getUTCFullYear()}`;
 };
 
 function FuelRow({
@@ -148,41 +156,26 @@ function FuelRow({
         </div>
       </summary>
 
-      <div className="px-4 pb-4 pt-2 border-t border-gray-100 bg-gray-50/40">
+      <div className="px-4 pb-4 pt-3 border-t border-gray-100 bg-gray-50/40">
         <div className="flex items-baseline justify-between mb-2">
           <p className="text-[11px] uppercase tracking-wide text-gray-500 font-semibold">
-            All brands
+            All {snapshot.stationCount} brand
+            {snapshot.stationCount === 1 ? '' : 's'}
           </p>
           <p className="text-[11px] text-gray-500 tabular-nums">
-            range {priceRange(snapshot)}
+            overall {priceRange(snapshot)} · avg {peso(snapshot.priceAvg)}
           </p>
         </div>
-        <dl className="space-y-1">
-          {sortedBrands.map((b, idx) => (
+        <dl className="space-y-0.5">
+          {sortedBrands.map((b) => (
             <div
               key={b.station}
-              className={`flex items-center justify-between gap-3 text-sm rounded-md px-2 py-1.5 ${
-                idx === 0 ? 'bg-white border border-gray-200' : ''
-              }`}
+              className="flex items-center justify-between gap-3 text-sm py-1.5 px-2 rounded"
             >
-              <dt className="flex items-center gap-2 text-gray-800">
-                {idx === 0 && (
-                  <span
-                    className="inline-block w-1.5 h-1.5 rounded-full"
-                    style={{ backgroundColor: color }}
-                    aria-hidden="true"
-                  />
-                )}
-                <span className="font-medium">{prettyBrand(b.station)}</span>
-                {idx === 0 && (
-                  <span className="text-[10px] uppercase tracking-wide text-emerald-600 font-semibold">
-                    cheapest
-                  </span>
-                )}
+              <dt className="font-medium text-gray-800">
+                {prettyBrand(b.station)}
               </dt>
-              <dd className="tabular-nums text-gray-900 font-medium">
-                {priceRange(b)}
-              </dd>
+              <dd className="tabular-nums text-gray-900">{priceRange(b)}</dd>
             </div>
           ))}
         </dl>
@@ -228,10 +221,10 @@ export default function FuelPricesSection() {
       {/* Header */}
       <div>
         <p className="text-[11px] uppercase tracking-[0.12em] text-primary-600 font-semibold">
-          Bacolod fuel prices
+          Latest DOE report
         </p>
-        <h2 className="mt-0.5 text-xl sm:text-2xl font-bold text-gray-900">
-          Week of {formatLongDate(fuelData.stats.latestWeek)}
+        <h2 className="mt-0.5 text-xl sm:text-2xl font-bold text-gray-900 tabular-nums">
+          {formatWeekRange(fuelData.stats.latestWeek)}
         </h2>
         <p className="mt-1 text-xs text-gray-500">
           {fuelData.stats.stationsSurveyed} brands surveyed ·{' '}
@@ -244,7 +237,7 @@ export default function FuelPricesSection() {
             DOE Oil Monitor
             <ExternalLink className="h-3 w-3" />
           </a>{' '}
-          · updated weekly
+          · DOE publishes a new report each week
         </p>
       </div>
 
@@ -259,11 +252,14 @@ export default function FuelPricesSection() {
         <FuelPricesChart />
       </div>
 
-      {/* Cheapest this week — flat list */}
+      {/* Cheapest in latest report — flat list */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 mb-2">
-          Cheapest this week
-        </h3>
+        <div className="flex items-baseline justify-between mb-2">
+          <h3 className="text-sm font-semibold text-gray-900">
+            Cheapest by fuel type
+          </h3>
+          <p className="text-[11px] text-gray-500">tap a row for all brands</p>
+        </div>
         <div className="space-y-2">
           {latestCards.map(({ snapshot, prior }) => (
             <FuelRow key={snapshot.id} snapshot={snapshot} prior={prior} />

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -58,12 +58,17 @@ const formatWeekRange = (iso: string) => {
   const start = new Date(Date.UTC(y, m - 1, d));
   const end = new Date(start);
   end.setUTCDate(end.getUTCDate() + 6);
-  const sameMonth = start.getUTCMonth() === end.getUTCMonth();
-  const startLabel = `${monthNames[start.getUTCMonth()]} ${start.getUTCDate()}`;
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
+  const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
+  const startMonth = monthNames[start.getUTCMonth()];
+  const endMonth = monthNames[end.getUTCMonth()];
+  if (!sameYear) {
+    return `${startMonth} ${start.getUTCDate()}, ${start.getUTCFullYear()} – ${endMonth} ${end.getUTCDate()}, ${end.getUTCFullYear()}`;
+  }
   const endLabel = sameMonth
     ? `${end.getUTCDate()}`
-    : `${monthNames[end.getUTCMonth()]} ${end.getUTCDate()}`;
-  return `${startLabel} – ${endLabel}, ${end.getUTCFullYear()}`;
+    : `${endMonth} ${end.getUTCDate()}`;
+  return `${startMonth} ${start.getUTCDate()} – ${endLabel}, ${end.getUTCFullYear()}`;
 };
 
 function FuelRow({
@@ -157,12 +162,13 @@ function FuelRow({
       </summary>
 
       <div className="px-4 pb-4 pt-3 border-t border-gray-100 bg-gray-50/40">
-        <div className="flex items-baseline justify-between mb-2">
+        <div className="flex items-baseline justify-between gap-3 mb-2">
           <p className="text-[11px] uppercase tracking-wide text-gray-500 font-semibold">
-            All {snapshot.stationCount} brand
-            {snapshot.stationCount === 1 ? '' : 's'}
+            {snapshot.stationCount === 1
+              ? 'Only 1 brand'
+              : `All ${snapshot.stationCount} brands`}
           </p>
-          <p className="text-[11px] text-gray-500 tabular-nums">
+          <p className="text-[11px] text-gray-500 tabular-nums flex-shrink-0">
             overall {priceRange(snapshot)} · avg {peso(snapshot.priceAvg)}
           </p>
         </div>
@@ -236,8 +242,7 @@ export default function FuelPricesSection() {
           >
             DOE Oil Monitor
             <ExternalLink className="h-3 w-3" />
-          </a>{' '}
-          · DOE publishes a new report each week
+          </a>
         </p>
       </div>
 
@@ -254,11 +259,13 @@ export default function FuelPricesSection() {
 
       {/* Cheapest in latest report — flat list */}
       <div>
-        <div className="flex items-baseline justify-between mb-2">
+        <div className="flex items-baseline justify-between gap-3 mb-2">
           <h3 className="text-sm font-semibold text-gray-900">
             Cheapest by fuel type
           </h3>
-          <p className="text-[11px] text-gray-500">tap a row for all brands</p>
+          <p className="text-[11px] text-gray-500 flex-shrink-0">
+            tap a row for all brands
+          </p>
         </div>
         <div className="space-y-2">
           {latestCards.map(({ snapshot, prior }) => (

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -28,9 +28,13 @@ export default function FuelPricesSection() {
     );
     if (latest.length === 0) return null;
 
-    const prior = fuelData.snapshots.filter(
-      (s) => s.date === fuelData.filters.weeks[1],
-    );
+    const priorWeek = fuelData.filters.weeks
+      .filter((w) => w < fuelData.stats.latestWeek)
+      .sort()
+      .at(-1);
+    const prior = priorWeek
+      ? fuelData.snapshots.filter((s) => s.date === priorWeek)
+      : [];
 
     const sortedByPrice = [...latest].sort((a, b) => a.priceAvg - b.priceAvg);
     const cheapest = sortedByPrice[0];
@@ -53,9 +57,9 @@ export default function FuelPricesSection() {
         <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
           <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
           <p>
-            Showing placeholder figures while we finalize the DOE data feed with{' '}
-            <span className="font-medium">@Shiro_Oni</span>. Numbers below are
-            illustrative and should not be used for purchasing decisions.
+            Placeholder figures while we finalize the DOE data feed with{' '}
+            <span className="font-medium">@Shiro_Oni</span>. Do not rely on
+            these for actual prices.
           </p>
         </div>
       )}
@@ -72,7 +76,7 @@ export default function FuelPricesSection() {
             </p>
           </div>
           <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
-            <p className="text-xs text-primary-600">Most expensive</p>
+            <p className="text-xs text-primary-600">Priciest</p>
             <p className="text-lg sm:text-xl font-bold text-primary-700">
               {peso(headline.priciest.priceAvg)}
             </p>
@@ -112,7 +116,7 @@ export default function FuelPricesSection() {
         </div>
       )}
 
-      <FuelPricesChart />
+      {fuelData.snapshots.length > 0 && <FuelPricesChart />}
 
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="relative flex-1">
@@ -128,6 +132,7 @@ export default function FuelPricesSection() {
         </div>
         <div className="relative">
           <select
+            aria-label="Filter by fuel type"
             value={fuelFilter}
             onChange={(e) => setFuelFilter(e.target.value)}
             className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -143,6 +148,7 @@ export default function FuelPricesSection() {
         </div>
         <div className="relative">
           <select
+            aria-label="Filter by week"
             value={weekFilter}
             onChange={(e) => setWeekFilter(e.target.value)}
             className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -245,14 +251,6 @@ export default function FuelPricesSection() {
           className="inline-flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white rounded text-sm hover:bg-primary-700"
         >
           DOE Oil Monitor <ExternalLink className="h-3 w-3" />
-        </a>
-        <a
-          href="https://www.doe.gov.ph/doe-oil-price-monitor"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 px-3 py-1.5 border border-primary-600 text-primary-600 rounded text-sm hover:bg-primary-50"
-        >
-          Weekly price bulletins <ExternalLink className="h-3 w-3" />
         </a>
       </div>
 

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -1,10 +1,28 @@
-import { ChevronDown, ExternalLink, Info, Search } from 'lucide-react';
+import { ChevronDown, ChevronRight, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import fuelData from '../../data/transparency/fuel-prices.json';
 import FuelPricesChart from './FuelPricesChart';
 
-type Snapshot = (typeof fuelData.snapshots)[number];
+type RawSnapshot = (typeof fuelData.snapshots)[number];
 type BrandPrice = { station: string; priceMin: number; priceMax: number };
+type FreshSnapshot = Omit<RawSnapshot, 'stale' | 'staleSince'>;
+type StaleSnapshot = FreshSnapshot & { stale: true; staleSince: string };
+type Snapshot = FreshSnapshot | StaleSnapshot;
+
+const isStaleSnapshot = (s: Snapshot): s is StaleSnapshot =>
+  'stale' in s && s.stale === true;
+
+const allSnapshots = fuelData.snapshots as Snapshot[];
+
+const GRADE_LABEL: Record<string, string> = {
+  'Gasoline RON 91': 'Regular unleaded',
+  'Gasoline RON 95': 'Premium',
+  'Gasoline RON 97': 'Super premium',
+  'Gasoline RON 100': 'Super premium',
+  Diesel: 'Diesel',
+  'Diesel Plus': 'Premium diesel',
+  Kerosene: 'Kerosene',
+};
 
 const peso = (v: number) => `₱${v.toFixed(2)}`;
 const priceRange = (p: { priceMin: number; priceMax: number }) =>
@@ -17,16 +35,159 @@ const prettyBrand = (s: string) =>
     ? 'Independent'
     : s
         .split(' ')
-        .map((w) => w[0] + w.slice(1).toLowerCase())
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
         .join(' ');
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+function FuelCard({
+  snapshot,
+  prior,
+}: {
+  snapshot: Snapshot;
+  prior?: Snapshot;
+}) {
+  const [open, setOpen] = useState(false);
+  const sortedBrands = [...(snapshot.byStation as BrandPrice[])].sort(
+    (a, b) => a.priceMin - b.priceMin,
+  );
+  const cheapest = sortedBrands[0];
+  if (!cheapest) return null;
+  const delta = prior ? snapshot.priceAvg - prior.priceAvg : null;
+  const grade = GRADE_LABEL[snapshot.fuelType] ?? snapshot.fuelType;
+  const labelId = `fuel-${slugify(snapshot.fuelType)}-${snapshot.date}`;
+  const isStale = isStaleSnapshot(snapshot);
+  const staleSince = isStale ? snapshot.staleSince : undefined;
+
+  return (
+    <article
+      aria-labelledby={labelId}
+      className="border border-gray-200 rounded-lg bg-white flex flex-col"
+    >
+      <div className="p-4 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p
+              id={labelId}
+              className="text-[11px] uppercase tracking-wide font-semibold text-gray-500"
+            >
+              {grade}
+            </p>
+            <p className="text-[11px] text-gray-400">{snapshot.fuelType}</p>
+          </div>
+          {isStale && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 text-[10px] font-medium whitespace-nowrap">
+              <span aria-hidden="true">no update</span>
+              <span className="sr-only">Carried forward from {staleSince}</span>
+            </span>
+          )}
+        </div>
+
+        <div className="mt-3 flex items-baseline gap-1.5">
+          <span className="text-3xl font-bold tabular-nums text-gray-900">
+            {peso(snapshot.priceAvg)}
+          </span>
+          <span className="text-[11px] text-gray-500">avg/L</span>
+        </div>
+
+        <p className="text-xs text-gray-600 tabular-nums mt-1">
+          {priceRange(snapshot)} · {snapshot.stationCount} brand
+          {snapshot.stationCount === 1 ? '' : 's'}
+        </p>
+
+        {delta !== null && !isStale && (
+          <p
+            className={`mt-1.5 text-[11px] tabular-nums font-medium ${
+              delta > 0.005
+                ? 'text-rose-600'
+                : delta < -0.005
+                  ? 'text-emerald-600'
+                  : 'text-gray-500'
+            }`}
+          >
+            <span aria-hidden="true">
+              {delta > 0.005 ? '▲' : delta < -0.005 ? '▼' : '■'}
+            </span>
+            <span className="sr-only">
+              {delta > 0.005
+                ? 'Increased by '
+                : delta < -0.005
+                  ? 'Decreased by '
+                  : 'Unchanged at '}
+            </span>{' '}
+            ₱{Math.abs(delta).toFixed(2)} vs last week
+          </p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex items-center justify-between gap-2 px-4 h-11 border-t border-gray-100 text-sm text-left text-primary-700 hover:bg-primary-50/60 rounded-b-lg"
+      >
+        <span className="truncate">
+          <span className="font-medium">{prettyBrand(cheapest.station)}</span>{' '}
+          <span className="tabular-nums text-gray-600">
+            {peso(cheapest.priceMin)}
+          </span>{' '}
+          <span className="text-xs text-gray-500">cheapest</span>
+        </span>
+        <ChevronRight
+          className={`h-4 w-4 flex-shrink-0 text-gray-400 transition-transform ${
+            open ? 'rotate-90' : ''
+          }`}
+        />
+      </button>
+
+      {open && (
+        <dl className="px-4 pb-4 pt-3 border-t border-gray-100 space-y-1.5">
+          {sortedBrands.map((b) => (
+            <div
+              key={b.station}
+              className="flex items-center justify-between gap-3 text-sm"
+            >
+              <dt className="text-gray-700">{prettyBrand(b.station)}</dt>
+              <dd className="tabular-nums text-gray-900 font-medium">
+                {priceRange(b)}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </article>
+  );
+}
 
 export default function FuelPricesSection() {
   const [search, setSearch] = useState('');
   const [fuelFilter, setFuelFilter] = useState('');
   const [weekFilter, setWeekFilter] = useState('');
 
+  const latestCards = useMemo(() => {
+    const latestWeek = fuelData.stats.latestWeek;
+    const priorWeek = fuelData.filters.weeks
+      .filter((w) => w < latestWeek)
+      .sort()
+      .at(-1);
+    const latest = allSnapshots.filter((s) => s.date === latestWeek);
+    const prior = priorWeek
+      ? allSnapshots.filter((s) => s.date === priorWeek)
+      : [];
+    const priorByType = new Map(prior.map((p) => [p.fuelType, p]));
+    return latest.map((s) => ({
+      snapshot: s,
+      prior: priorByType.get(s.fuelType),
+    }));
+  }, []);
+
   const filtered = useMemo(() => {
-    return fuelData.snapshots.filter((s: Snapshot) => {
+    return allSnapshots.filter((s) => {
       const matchSearch =
         !search || s.fuelType.toLowerCase().includes(search.toLowerCase());
       const matchFuel = !fuelFilter || s.fuelType === fuelFilter;
@@ -35,341 +196,206 @@ export default function FuelPricesSection() {
     });
   }, [search, fuelFilter, weekFilter]);
 
-  const headline = useMemo(() => {
-    const latest = fuelData.snapshots.filter(
-      (s) => s.date === fuelData.stats.latestWeek,
-    );
-    if (latest.length === 0) return null;
-
-    const priorWeek = fuelData.filters.weeks
-      .filter((w) => w < fuelData.stats.latestWeek)
-      .sort()
-      .at(-1);
-    const prior = priorWeek
-      ? fuelData.snapshots.filter((s) => s.date === priorWeek)
-      : [];
-
-    const sortedByPrice = [...latest].sort((a, b) => a.priceAvg - b.priceAvg);
-    const cheapest = sortedByPrice[0];
-    const priciest = sortedByPrice[sortedByPrice.length - 1];
-
-    const sharedTypes = new Set(
-      latest
-        .map((s) => s.fuelType)
-        .filter((t) => prior.some((p) => p.fuelType === t)),
-    );
-    const latestShared = latest.filter((s) => sharedTypes.has(s.fuelType));
-    const priorShared = prior.filter((s) => sharedTypes.has(s.fuelType));
-    const weeklyChange =
-      priorShared.length > 0
-        ? latestShared.reduce((sum, s) => sum + s.priceAvg, 0) /
-            latestShared.length -
-          priorShared.reduce((sum, s) => sum + s.priceAvg, 0) /
-            priorShared.length
-        : 0;
-
-    return { cheapest, priciest, weeklyChange };
-  }, []);
-
-  const latestByBrand = useMemo(() => {
-    const latest = fuelData.snapshots.filter(
-      (s) => s.date === fuelData.stats.latestWeek,
-    );
-    const fuelTypes = latest.map((s) => s.fuelType);
-    const brandSet = new Set<string>();
-    const matrix: Record<string, Record<string, BrandPrice>> = {};
-    for (const snap of latest) {
-      for (const b of snap.byStation as BrandPrice[]) {
-        brandSet.add(b.station);
-        if (!matrix[b.station]) matrix[b.station] = {};
-        matrix[b.station][snap.fuelType] = b;
-      }
-    }
-    const BRAND_PRIORITY = ['SHELL', 'PETRON', 'CALTEX', 'TOTAL', 'SEAOIL'];
-    const brands = [...brandSet].sort((a, b) => {
-      const ai = BRAND_PRIORITY.indexOf(a);
-      const bi = BRAND_PRIORITY.indexOf(b);
-      if (ai !== -1 && bi !== -1) return ai - bi;
-      if (ai !== -1) return -1;
-      if (bi !== -1) return 1;
-      return a.localeCompare(b);
-    });
-    return { brands, fuelTypes, matrix };
-  }, []);
-
   return (
-    <div className="space-y-4">
-      {fuelData.placeholder && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
-          <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
-          <p>
-            Placeholder figures while we finalize the DOE data feed with{' '}
-            <span className="font-medium">@Shiro_Oni</span>. Do not rely on
-            these for actual prices.
-          </p>
-        </div>
-      )}
-
-      {headline && (
-        <div className="grid grid-cols-3 gap-2 sm:gap-3 text-center">
-          <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
-            <p className="text-xs text-primary-600">Cheapest</p>
-            <p className="text-lg sm:text-xl font-bold text-primary-700">
-              {peso(headline.cheapest.priceAvg)}
-            </p>
-            <p className="text-[10px] text-primary-600/80 truncate">
-              {headline.cheapest.fuelType}
-            </p>
-          </div>
-          <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
-            <p className="text-xs text-primary-600">Priciest</p>
-            <p className="text-lg sm:text-xl font-bold text-primary-700">
-              {peso(headline.priciest.priceAvg)}
-            </p>
-            <p className="text-[10px] text-primary-600/80 truncate">
-              {headline.priciest.fuelType}
-            </p>
-          </div>
-          <div className="bg-primary-50 rounded-lg p-2 sm:p-3">
-            <p className="text-xs text-primary-600">Weekly change</p>
-            <p
-              className={`text-lg sm:text-xl font-bold ${
-                headline.weeklyChange > 0
-                  ? 'text-rose-600'
-                  : headline.weeklyChange < 0
-                    ? 'text-emerald-600'
-                    : 'text-primary-700'
-              }`}
-            >
-              <span aria-hidden="true">
-                {headline.weeklyChange > 0
-                  ? '▲'
-                  : headline.weeklyChange < 0
-                    ? '▼'
-                    : '■'}
-              </span>
-              <span className="sr-only">
-                {headline.weeklyChange > 0
-                  ? 'Increased by '
-                  : headline.weeklyChange < 0
-                    ? 'Decreased by '
-                    : 'Unchanged at '}
-              </span>{' '}
-              ₱{Math.abs(headline.weeklyChange).toFixed(2)}
-            </p>
-            <p className="text-[10px] text-primary-600/80">vs prior week</p>
-          </div>
-        </div>
-      )}
-
-      <div className="flex items-start gap-2 bg-primary-50 border border-primary-100 rounded-lg p-3 text-xs text-primary-800">
-        <Info className="h-4 w-4 flex-shrink-0 mt-0.5" />
-        <p>
-          <span className="font-medium">Fuel grade guide:</span> RON is the
-          octane rating. <span className="font-medium">RON 91</span> = regular
-          unleaded, <span className="font-medium">RON 95</span> = premium,{' '}
-          <span className="font-medium">RON 97 / 100</span> = super premium.{' '}
-          <span className="font-medium">Diesel Plus</span> is premium diesel.
-        </p>
-      </div>
-
-      {fuelData.snapshots.length > 0 && <FuelPricesChart />}
-
-      {latestByBrand.brands.length > 0 && (
-        <div className="border border-gray-200 rounded-lg overflow-hidden">
-          <div className="bg-gray-50 px-3 py-2 border-b border-gray-200">
-            <h3 className="text-sm font-semibold text-gray-900">
-              Latest week by brand
-            </h3>
-            <p className="text-xs text-gray-500">
-              Price range per brand for the week of {fuelData.stats.latestWeek}.
-              Source: DOE survey.
-            </p>
-          </div>
-          <div className="overflow-x-auto">
-            <table
-              className="w-full text-sm"
-              aria-label="Latest week fuel prices by brand"
-            >
-              <thead className="bg-gray-50">
-                <tr>
-                  <th
-                    scope="col"
-                    className="text-left py-2 px-3 font-medium text-gray-600 whitespace-nowrap"
-                  >
-                    Brand
-                  </th>
-                  {latestByBrand.fuelTypes.map((t) => (
-                    <th
-                      key={t}
-                      scope="col"
-                      className="text-right py-2 px-3 font-medium text-gray-600 whitespace-nowrap"
-                    >
-                      {t.replace('Gasoline ', '')}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {latestByBrand.brands.map((brand) => (
-                  <tr key={brand} className="hover:bg-gray-50">
-                    <td className="py-2 px-3 font-medium text-gray-900 whitespace-nowrap">
-                      {prettyBrand(brand)}
-                    </td>
-                    {latestByBrand.fuelTypes.map((t) => {
-                      const cell = latestByBrand.matrix[brand]?.[t];
-                      return (
-                        <td
-                          key={t}
-                          className="py-2 px-3 text-right text-gray-700 whitespace-nowrap"
-                        >
-                          {cell ? priceRange(cell) : '—'}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      )}
-
-      <div className="flex flex-col sm:flex-row gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <input
-            type="text"
-            aria-label="Search fuel type"
-            placeholder="Search fuel type..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-          />
-        </div>
-        <div className="relative">
-          <select
-            aria-label="Filter by fuel type"
-            value={fuelFilter}
-            onChange={(e) => setFuelFilter(e.target.value)}
-            className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
-          >
-            <option value="">All fuel types</option>
-            {fuelData.filters.fuelTypes.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-          <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-        </div>
-        <div className="relative">
-          <select
-            aria-label="Filter by week"
-            value={weekFilter}
-            onChange={(e) => setWeekFilter(e.target.value)}
-            className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
-          >
-            <option value="">All weeks</option>
-            {fuelData.filters.weeks.map((w) => (
-              <option key={w} value={w}>
-                {w}
-              </option>
-            ))}
-          </select>
-          <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-        </div>
-      </div>
-
-      <div className="border border-gray-200 rounded-lg overflow-hidden">
-        <div className="max-h-[400px] overflow-y-auto">
-          <table
-            className="w-full text-sm"
-            aria-label="Weekly fuel price snapshots"
-          >
-            <thead className="bg-gray-50 sticky top-0">
-              <tr>
-                <th
-                  scope="col"
-                  className="text-left py-2 px-3 font-medium text-gray-600"
-                >
-                  Week
-                </th>
-                <th
-                  scope="col"
-                  className="text-left py-2 px-3 font-medium text-gray-600"
-                >
-                  Fuel type
-                </th>
-                <th
-                  scope="col"
-                  className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
-                >
-                  Min
-                </th>
-                <th
-                  scope="col"
-                  className="text-right py-2 px-3 font-medium text-gray-600"
-                >
-                  Avg
-                </th>
-                <th
-                  scope="col"
-                  className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
-                >
-                  Max
-                </th>
-                <th
-                  scope="col"
-                  className="text-right py-2 px-3 font-medium text-gray-600 hidden md:table-cell"
-                >
-                  Stations
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {filtered.map((s) => (
-                <tr key={s.id} className="hover:bg-gray-50">
-                  <td className="py-2 px-3 text-gray-900 whitespace-nowrap">
-                    {s.date}
-                  </td>
-                  <td className="py-2 px-3 text-gray-700">{s.fuelType}</td>
-                  <td className="py-2 px-3 text-right text-gray-700 hidden sm:table-cell whitespace-nowrap">
-                    {peso(s.priceMin)}
-                  </td>
-                  <td className="py-2 px-3 text-right text-gray-900 font-medium whitespace-nowrap">
-                    {peso(s.priceAvg)}
-                  </td>
-                  <td className="py-2 px-3 text-right text-gray-700 hidden sm:table-cell whitespace-nowrap">
-                    {peso(s.priceMax)}
-                  </td>
-                  <td className="py-2 px-3 text-right text-gray-600 hidden md:table-cell">
-                    {s.stationCount}
-                  </td>
-                </tr>
-              ))}
-              {filtered.length === 0 && (
-                <tr>
-                  <td colSpan={6} className="py-8 text-center text-gray-500">
-                    No snapshots for this fuel type in the selected range
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div className="flex flex-wrap gap-2 pt-2">
+    <div className="space-y-4 lg:space-y-6">
+      <p className="text-xs text-gray-500">
+        Week of{' '}
+        <span className="font-medium text-gray-700 tabular-nums">
+          {fuelData.stats.latestWeek}
+        </span>{' '}
+        · {fuelData.stats.stationsSurveyed} brands surveyed ·{' '}
         <a
           href={fuelData.sourceUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 px-3 py-1.5 bg-primary-600 text-white rounded text-sm hover:bg-primary-700"
+          className="underline hover:text-primary-700"
         >
-          DOE Oil Monitor <ExternalLink className="h-3 w-3" />
+          DOE Oil Monitor
         </a>
+      </p>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        {latestCards.map(({ snapshot, prior }) => (
+          <FuelCard key={snapshot.id} snapshot={snapshot} prior={prior} />
+        ))}
       </div>
+
+      <details className="group border border-gray-200 rounded-lg bg-white open:shadow-sm">
+        <summary className="flex items-center justify-between gap-2 px-4 h-11 cursor-pointer list-none text-sm font-medium text-gray-800 rounded-lg hover:bg-gray-50">
+          <span>Price trend · {fuelData.stats.weeksTracked} weeks</span>
+          <ChevronDown className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" />
+        </summary>
+        <div className="px-3 pb-3">
+          {allSnapshots.length > 0 && <FuelPricesChart />}
+        </div>
+      </details>
+
+      <details className="group border border-gray-200 rounded-lg bg-white">
+        <summary className="flex items-center justify-between gap-2 px-4 h-11 cursor-pointer list-none text-sm font-medium text-gray-800 rounded-lg hover:bg-gray-50">
+          <span>All weekly snapshots</span>
+          <ChevronDown className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" />
+        </summary>
+        <div className="p-3 space-y-3">
+          <div className="flex flex-col sm:flex-row gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                aria-label="Search fuel type"
+                placeholder="Search fuel type..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              />
+            </div>
+            <div className="relative">
+              <select
+                aria-label="Filter by fuel type"
+                value={fuelFilter}
+                onChange={(e) => setFuelFilter(e.target.value)}
+                className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                <option value="">All fuel types</option>
+                {fuelData.filters.fuelTypes.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+            </div>
+            <div className="relative">
+              <select
+                aria-label="Filter by week"
+                value={weekFilter}
+                onChange={(e) => setWeekFilter(e.target.value)}
+                className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+              >
+                <option value="">All weeks</option>
+                {fuelData.filters.weeks.map((w) => (
+                  <option key={w} value={w}>
+                    {w}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+            </div>
+          </div>
+
+          <div className="border border-gray-200 rounded-lg overflow-hidden">
+            <div className="max-h-[400px] overflow-y-auto">
+              <table
+                className="w-full text-sm"
+                aria-label="Weekly fuel price snapshots"
+              >
+                <thead className="bg-gray-50 sticky top-0">
+                  <tr>
+                    <th
+                      scope="col"
+                      className="text-left py-2 px-3 font-medium text-gray-600"
+                    >
+                      Week
+                    </th>
+                    <th
+                      scope="col"
+                      className="text-left py-2 px-3 font-medium text-gray-600"
+                    >
+                      Fuel type
+                    </th>
+                    <th
+                      scope="col"
+                      className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
+                    >
+                      Min
+                    </th>
+                    <th
+                      scope="col"
+                      className="text-right py-2 px-3 font-medium text-gray-600"
+                    >
+                      Avg
+                    </th>
+                    <th
+                      scope="col"
+                      className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
+                    >
+                      Max
+                    </th>
+                    <th
+                      scope="col"
+                      className="text-right py-2 px-3 font-medium text-gray-600 hidden md:table-cell"
+                    >
+                      Brands
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {filtered.map((s) => {
+                    const stale = isStaleSnapshot(s);
+                    return (
+                      <tr
+                        key={s.id}
+                        className={`hover:bg-gray-50 ${stale ? 'text-gray-400' : ''}`}
+                      >
+                        <td className="py-2 px-3 whitespace-nowrap tabular-nums">
+                          {s.date}
+                        </td>
+                        <td className="py-2 px-3">
+                          {s.fuelType}
+                          {stale && (
+                            <span className="ml-1.5 text-[10px] uppercase tracking-wide text-amber-600">
+                              stale
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2 px-3 text-right hidden sm:table-cell whitespace-nowrap tabular-nums">
+                          {peso(s.priceMin)}
+                        </td>
+                        <td className="py-2 px-3 text-right font-medium whitespace-nowrap tabular-nums">
+                          {peso(s.priceAvg)}
+                        </td>
+                        <td className="py-2 px-3 text-right hidden sm:table-cell whitespace-nowrap tabular-nums">
+                          {peso(s.priceMax)}
+                        </td>
+                        <td className="py-2 px-3 text-right hidden md:table-cell tabular-nums">
+                          {s.stationCount}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                  {filtered.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={6}
+                        className="py-8 text-center text-gray-500"
+                      >
+                        No snapshots for this fuel type in the selected range
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </details>
+
+      <details className="text-xs text-gray-600">
+        <summary className="cursor-pointer text-primary-700 hover:underline">
+          What do RON 91 / 95 / 97 / 100 mean?
+        </summary>
+        <div className="mt-2 space-y-1 pl-2 border-l-2 border-gray-200">
+          <p>
+            <span className="font-medium">RON</span> is the octane rating of
+            gasoline. Higher RON = better engine performance, higher price.
+          </p>
+          <p>
+            <span className="font-medium">RON 91</span> is regular unleaded,{' '}
+            <span className="font-medium">RON 95</span> is premium,{' '}
+            <span className="font-medium">RON 97 / 100</span> are super premium.{' '}
+            <span className="font-medium">Diesel Plus</span> is premium diesel.
+          </p>
+        </div>
+      </details>
 
       <p className="text-xs text-gray-500 pt-2">
         Source:{' '}
@@ -383,7 +409,8 @@ export default function FuelPricesSection() {
         </a>{' '}
         • DOE publishes updated prices weekly • Data contributed by{' '}
         <span className="font-medium">@{fuelData.contributor}</span> • Last
-        updated {fuelData.lastUpdated} • Report issues:{' '}
+        updated <span className="tabular-nums">{fuelData.lastUpdated}</span> •
+        Report issues:{' '}
         <a
           href="https://sumbongsapangulo.ph/"
           target="_blank"

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -1,7 +1,7 @@
-import { ChevronDown, ChevronRight, Search } from 'lucide-react';
+import { ChevronDown, ExternalLink, Search } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import fuelData from '../../data/transparency/fuel-prices.json';
-import FuelPricesChart from './FuelPricesChart';
+import FuelPricesChart, { FUEL_COLORS } from './FuelPricesChart';
 
 type RawSnapshot = (typeof fuelData.snapshots)[number];
 type BrandPrice = { station: string; priceMin: number; priceMax: number };
@@ -39,20 +39,32 @@ const prettyBrand = (s: string) =>
         .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
         .join(' ');
 
-const slugify = (s: string) =>
-  s
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+const formatLongDate = (iso: string) => {
+  const [y, m, d] = iso.split('-');
+  return `${monthNames[Number(m) - 1]} ${Number(d)}, ${y}`;
+};
 
-function FuelCard({
+function FuelRow({
   snapshot,
   prior,
 }: {
   snapshot: Snapshot;
   prior?: Snapshot;
 }) {
-  const [open, setOpen] = useState(false);
   const sortedBrands = [...(snapshot.byStation as BrandPrice[])].sort(
     (a, b) => a.priceMin - b.priceMin,
   );
@@ -60,107 +72,122 @@ function FuelCard({
   if (!cheapest) return null;
   const delta = prior ? snapshot.priceAvg - prior.priceAvg : null;
   const grade = GRADE_LABEL[snapshot.fuelType] ?? snapshot.fuelType;
-  const labelId = `fuel-${slugify(snapshot.fuelType)}-${snapshot.date}`;
   const isStale = isStaleSnapshot(snapshot);
-  const staleSince = isStale ? snapshot.staleSince : undefined;
+  const color = FUEL_COLORS[snapshot.fuelType] ?? '#6b7280';
 
   return (
-    <article
-      aria-labelledby={labelId}
-      className="border border-gray-200 rounded-lg bg-white flex flex-col"
-    >
-      <div className="p-4 flex-1">
-        <div className="flex items-start justify-between gap-2">
-          <div>
-            <p
-              id={labelId}
-              className="text-[11px] uppercase tracking-wide font-semibold text-gray-500"
-            >
-              {grade}
-            </p>
-            <p className="text-[11px] text-gray-400">{snapshot.fuelType}</p>
-          </div>
-          {isStale && (
-            <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 text-[10px] font-medium whitespace-nowrap">
-              <span aria-hidden="true">no update</span>
-              <span className="sr-only">Carried forward from {staleSince}</span>
-            </span>
-          )}
-        </div>
-
-        <div className="mt-3 flex items-baseline gap-1.5">
-          <span className="text-3xl font-bold tabular-nums text-gray-900">
-            {peso(snapshot.priceAvg)}
-          </span>
-          <span className="text-[11px] text-gray-500">avg/L</span>
-        </div>
-
-        <p className="text-xs text-gray-600 tabular-nums mt-1">
-          {priceRange(snapshot)} · {snapshot.stationCount} brand
-          {snapshot.stationCount === 1 ? '' : 's'}
-        </p>
-
-        {delta !== null && !isStale && (
-          <p
-            className={`mt-1.5 text-[11px] tabular-nums font-medium ${
-              delta > 0.005
-                ? 'text-rose-600'
-                : delta < -0.005
-                  ? 'text-emerald-600'
-                  : 'text-gray-500'
-            }`}
-          >
-            <span aria-hidden="true">
-              {delta > 0.005 ? '▲' : delta < -0.005 ? '▼' : '■'}
-            </span>
-            <span className="sr-only">
-              {delta > 0.005
-                ? 'Increased by '
-                : delta < -0.005
-                  ? 'Decreased by '
-                  : 'Unchanged at '}
-            </span>{' '}
-            ₱{Math.abs(delta).toFixed(2)} vs last week
-          </p>
-        )}
-      </div>
-
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="flex items-center justify-between gap-2 px-4 h-11 border-t border-gray-100 text-sm text-left text-primary-700 hover:bg-primary-50/60 rounded-b-lg"
-      >
-        <span className="truncate">
-          <span className="font-medium">{prettyBrand(cheapest.station)}</span>{' '}
-          <span className="tabular-nums text-gray-600">
-            {peso(cheapest.priceMin)}
-          </span>{' '}
-          <span className="text-xs text-gray-500">cheapest</span>
-        </span>
-        <ChevronRight
-          className={`h-4 w-4 flex-shrink-0 text-gray-400 transition-transform ${
-            open ? 'rotate-90' : ''
-          }`}
+    <details className="group rounded-xl bg-white border border-gray-200 open:shadow-md open:border-gray-300 transition-shadow overflow-hidden">
+      <summary className="flex items-stretch gap-3 cursor-pointer list-none p-4 hover:bg-gray-50/70">
+        <div
+          className="w-1 rounded-full flex-shrink-0"
+          style={{ backgroundColor: color }}
+          aria-hidden="true"
         />
-      </button>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="text-[13px] font-semibold text-gray-900">{grade}</p>
+            <p className="text-[11px] text-gray-400 tabular-nums">
+              {snapshot.fuelType}
+            </p>
+            {isStale && (
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 text-[10px] font-medium">
+                <span aria-hidden="true">no update</span>
+                <span className="sr-only">
+                  Carried forward from {snapshot.staleSince}
+                </span>
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-[12px] text-gray-600 tabular-nums">
+            Cheapest at{' '}
+            <span className="font-semibold text-gray-900">
+              {prettyBrand(cheapest.station)}
+            </span>{' '}
+            ·{' '}
+            <span className="text-gray-500">
+              {snapshot.stationCount} brand
+              {snapshot.stationCount === 1 ? '' : 's'}
+            </span>
+          </p>
+        </div>
+        <div className="flex flex-col items-end justify-between gap-1 flex-shrink-0">
+          <p className="text-2xl font-bold tabular-nums text-gray-900 leading-none">
+            {peso(cheapest.priceMin)}
+          </p>
+          {delta !== null && !isStale ? (
+            <p
+              className={`text-[10px] tabular-nums font-medium flex items-center gap-0.5 ${
+                delta > 0.005
+                  ? 'text-rose-600'
+                  : delta < -0.005
+                    ? 'text-emerald-600'
+                    : 'text-gray-500'
+              }`}
+            >
+              <span aria-hidden="true">
+                {delta > 0.005 ? '▲' : delta < -0.005 ? '▼' : '■'}
+              </span>
+              <span className="sr-only">
+                {delta > 0.005
+                  ? 'Increased by '
+                  : delta < -0.005
+                    ? 'Decreased by '
+                    : 'Unchanged at '}
+              </span>
+              ₱{Math.abs(delta).toFixed(2)}
+            </p>
+          ) : (
+            <p className="text-[10px] text-gray-400 tabular-nums">
+              avg {peso(snapshot.priceAvg)}
+            </p>
+          )}
+          <ChevronDown
+            className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180"
+            aria-hidden="true"
+          />
+        </div>
+      </summary>
 
-      {open && (
-        <dl className="px-4 pb-4 pt-3 border-t border-gray-100 space-y-1.5">
-          {sortedBrands.map((b) => (
+      <div className="px-4 pb-4 pt-2 border-t border-gray-100 bg-gray-50/40">
+        <div className="flex items-baseline justify-between mb-2">
+          <p className="text-[11px] uppercase tracking-wide text-gray-500 font-semibold">
+            All brands
+          </p>
+          <p className="text-[11px] text-gray-500 tabular-nums">
+            range {priceRange(snapshot)}
+          </p>
+        </div>
+        <dl className="space-y-1">
+          {sortedBrands.map((b, idx) => (
             <div
               key={b.station}
-              className="flex items-center justify-between gap-3 text-sm"
+              className={`flex items-center justify-between gap-3 text-sm rounded-md px-2 py-1.5 ${
+                idx === 0 ? 'bg-white border border-gray-200' : ''
+              }`}
             >
-              <dt className="text-gray-700">{prettyBrand(b.station)}</dt>
+              <dt className="flex items-center gap-2 text-gray-800">
+                {idx === 0 && (
+                  <span
+                    className="inline-block w-1.5 h-1.5 rounded-full"
+                    style={{ backgroundColor: color }}
+                    aria-hidden="true"
+                  />
+                )}
+                <span className="font-medium">{prettyBrand(b.station)}</span>
+                {idx === 0 && (
+                  <span className="text-[10px] uppercase tracking-wide text-emerald-600 font-semibold">
+                    cheapest
+                  </span>
+                )}
+              </dt>
               <dd className="tabular-nums text-gray-900 font-medium">
                 {priceRange(b)}
               </dd>
             </div>
           ))}
         </dl>
-      )}
-    </article>
+      </div>
+    </details>
   );
 }
 
@@ -197,45 +224,85 @@ export default function FuelPricesSection() {
   }, [search, fuelFilter, weekFilter]);
 
   return (
-    <div className="space-y-4 lg:space-y-6">
-      <p className="text-xs text-gray-500">
-        Week of{' '}
-        <span className="font-medium text-gray-700 tabular-nums">
-          {fuelData.stats.latestWeek}
-        </span>{' '}
-        · {fuelData.stats.stationsSurveyed} brands surveyed ·{' '}
-        <a
-          href={fuelData.sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline hover:text-primary-700"
-        >
-          DOE Oil Monitor
-        </a>
-      </p>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        {latestCards.map(({ snapshot, prior }) => (
-          <FuelCard key={snapshot.id} snapshot={snapshot} prior={prior} />
-        ))}
+    <div className="space-y-5 lg:space-y-7">
+      {/* Header */}
+      <div>
+        <p className="text-[11px] uppercase tracking-[0.12em] text-primary-600 font-semibold">
+          Bacolod fuel prices
+        </p>
+        <h2 className="mt-0.5 text-xl sm:text-2xl font-bold text-gray-900">
+          Week of {formatLongDate(fuelData.stats.latestWeek)}
+        </h2>
+        <p className="mt-1 text-xs text-gray-500">
+          {fuelData.stats.stationsSurveyed} brands surveyed ·{' '}
+          <a
+            href={fuelData.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-primary-700 inline-flex items-center gap-0.5"
+          >
+            DOE Oil Monitor
+            <ExternalLink className="h-3 w-3" />
+          </a>{' '}
+          · updated weekly
+        </p>
       </div>
 
-      <details className="group border border-gray-200 rounded-lg bg-white open:shadow-sm">
-        <summary className="flex items-center justify-between gap-2 px-4 h-11 cursor-pointer list-none text-sm font-medium text-gray-800 rounded-lg hover:bg-gray-50">
-          <span>Price trend · {fuelData.stats.weeksTracked} weeks</span>
-          <ChevronDown className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" />
+      {/* Hero: price trend chart */}
+      <div>
+        <div className="flex items-baseline justify-between mb-2">
+          <h3 className="text-sm font-semibold text-gray-900">
+            {fuelData.stats.weeksTracked}-week trend
+          </h3>
+          <p className="text-[11px] text-gray-500">tap legend to toggle</p>
+        </div>
+        <FuelPricesChart />
+      </div>
+
+      {/* Cheapest this week — flat list */}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900 mb-2">
+          Cheapest this week
+        </h3>
+        <div className="space-y-2">
+          {latestCards.map(({ snapshot, prior }) => (
+            <FuelRow key={snapshot.id} snapshot={snapshot} prior={prior} />
+          ))}
+        </div>
+      </div>
+
+      {/* What's RON — inline help */}
+      <details className="text-xs">
+        <summary className="cursor-pointer list-none text-primary-700 hover:underline font-medium inline-flex items-center gap-1">
+          <span>What do RON 91 / 95 / 97 / 100 mean?</span>
+          <ChevronDown className="h-3.5 w-3.5 transition-transform group-open:rotate-180" />
         </summary>
-        <div className="px-3 pb-3">
-          {allSnapshots.length > 0 && <FuelPricesChart />}
+        <div className="mt-2 space-y-1 pl-3 border-l-2 border-gray-200 text-gray-600">
+          <p>
+            <span className="font-medium text-gray-800">RON</span> is the octane
+            rating — higher number, higher resistance to knocking, higher price.
+          </p>
+          <p>
+            <span className="font-medium text-gray-800">RON 91</span> regular
+            unleaded · <span className="font-medium text-gray-800">RON 95</span>{' '}
+            premium ·{' '}
+            <span className="font-medium text-gray-800">RON 97 / 100</span>{' '}
+            super premium ·{' '}
+            <span className="font-medium text-gray-800">Diesel Plus</span>{' '}
+            premium diesel.
+          </p>
         </div>
       </details>
 
-      <details className="group border border-gray-200 rounded-lg bg-white">
-        <summary className="flex items-center justify-between gap-2 px-4 h-11 cursor-pointer list-none text-sm font-medium text-gray-800 rounded-lg hover:bg-gray-50">
-          <span>All weekly snapshots</span>
+      {/* Full data table — collapsed */}
+      <details className="group rounded-xl border border-gray-200 bg-white">
+        <summary className="flex items-center justify-between gap-2 px-4 h-11 cursor-pointer list-none text-sm font-medium text-gray-800 rounded-xl hover:bg-gray-50">
+          <span>
+            All weekly snapshots ({fuelData.stats.weeksTracked} weeks)
+          </span>
           <ChevronDown className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" />
         </summary>
-        <div className="p-3 space-y-3">
+        <div className="p-3 space-y-3 border-t border-gray-100">
           <div className="flex flex-col sm:flex-row gap-2">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
@@ -379,24 +446,6 @@ export default function FuelPricesSection() {
         </div>
       </details>
 
-      <details className="text-xs text-gray-600">
-        <summary className="cursor-pointer text-primary-700 hover:underline">
-          What do RON 91 / 95 / 97 / 100 mean?
-        </summary>
-        <div className="mt-2 space-y-1 pl-2 border-l-2 border-gray-200">
-          <p>
-            <span className="font-medium">RON</span> is the octane rating of
-            gasoline. Higher RON = better engine performance, higher price.
-          </p>
-          <p>
-            <span className="font-medium">RON 91</span> is regular unleaded,{' '}
-            <span className="font-medium">RON 95</span> is premium,{' '}
-            <span className="font-medium">RON 97 / 100</span> are super premium.{' '}
-            <span className="font-medium">Diesel Plus</span> is premium diesel.
-          </p>
-        </div>
-      </details>
-
       <p className="text-xs text-gray-500 pt-2">
         Source:{' '}
         <a
@@ -407,9 +456,9 @@ export default function FuelPricesSection() {
         >
           {fuelData.source}
         </a>{' '}
-        • DOE publishes updated prices weekly • Data contributed by{' '}
-        <span className="font-medium">@{fuelData.contributor}</span> • Last
-        updated <span className="tabular-nums">{fuelData.lastUpdated}</span> •
+        · DOE publishes updated prices weekly · Data contributed by{' '}
+        <span className="font-medium">@{fuelData.contributor}</span> · Last
+        updated <span className="tabular-nums">{fuelData.lastUpdated}</span> ·
         Report issues:{' '}
         <a
           href="https://sumbongsapangulo.ph/"

--- a/src/components/transparency/FuelPricesSection.tsx
+++ b/src/components/transparency/FuelPricesSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ExternalLink, Search } from 'lucide-react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import fuelData from '../../data/transparency/fuel-prices.json';
 import FuelPricesChart, { FUEL_COLORS } from './FuelPricesChart';
@@ -232,7 +232,6 @@ function FuelRow({
 }
 
 export default function FuelPricesSection() {
-  const [search, setSearch] = useState('');
   const [fuelFilter, setFuelFilter] = useState('');
   const [weekFilter, setWeekFilter] = useState('');
 
@@ -261,13 +260,11 @@ export default function FuelPricesSection() {
 
   const filtered = useMemo(() => {
     return allSnapshots.filter((s) => {
-      const matchSearch =
-        !search || s.fuelType.toLowerCase().includes(search.toLowerCase());
       const matchFuel = !fuelFilter || s.fuelType === fuelFilter;
       const matchWeek = !weekFilter || s.date === weekFilter;
-      return matchSearch && matchFuel && matchWeek;
+      return matchFuel && matchWeek;
     });
-  }, [search, fuelFilter, weekFilter]);
+  }, [fuelFilter, weekFilter]);
 
   return (
     <div className="space-y-5 lg:space-y-7">
@@ -385,24 +382,13 @@ export default function FuelPricesSection() {
           <ChevronDown className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" />
         </summary>
         <div className="p-3 space-y-3 border-t border-gray-100">
-          <div className="flex flex-col sm:flex-row gap-2">
-            <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-              <input
-                type="text"
-                aria-label="Search fuel type"
-                placeholder="Search fuel type..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-              />
-            </div>
+          <div className="grid grid-cols-2 gap-2">
             <div className="relative">
               <select
                 aria-label="Filter by fuel type"
                 value={fuelFilter}
                 onChange={(e) => setFuelFilter(e.target.value)}
-                className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="appearance-none w-full pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
               >
                 <option value="">All fuel types</option>
                 {fuelData.filters.fuelTypes.map((t) => (
@@ -418,12 +404,12 @@ export default function FuelPricesSection() {
                 aria-label="Filter by week"
                 value={weekFilter}
                 onChange={(e) => setWeekFilter(e.target.value)}
-                className="appearance-none pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="appearance-none w-full pl-3 pr-8 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary-500"
               >
                 <option value="">All weeks</option>
                 {fuelData.filters.weeks.map((w) => (
                   <option key={w} value={w}>
-                    {w}
+                    {formatWeekRangeShort(w)}
                   </option>
                 ))}
               </select>
@@ -449,25 +435,13 @@ export default function FuelPricesSection() {
                       scope="col"
                       className="text-left py-2 px-3 font-medium text-gray-600"
                     >
-                      Fuel type
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
-                    >
-                      Min
+                      Fuel
                     </th>
                     <th
                       scope="col"
                       className="text-right py-2 px-3 font-medium text-gray-600"
                     >
-                      Avg
-                    </th>
-                    <th
-                      scope="col"
-                      className="text-right py-2 px-3 font-medium text-gray-600 hidden sm:table-cell"
-                    >
-                      Max
+                      Price (₱/L)
                     </th>
                     <th
                       scope="col"
@@ -480,32 +454,41 @@ export default function FuelPricesSection() {
                 <tbody className="divide-y divide-gray-100">
                   {filtered.map((s) => {
                     const stale = isStaleSnapshot(s);
+                    const color = FUEL_COLORS[s.fuelType] ?? '#6b7280';
                     return (
                       <tr
                         key={s.id}
                         className={`hover:bg-gray-50 ${stale ? 'text-gray-400' : ''}`}
                       >
-                        <td className="py-2 px-3 whitespace-nowrap tabular-nums">
-                          {s.date}
+                        <td className="py-2 px-3 whitespace-nowrap tabular-nums text-[12px] text-gray-600">
+                          {formatWeekRangeShort(s.date)}
                         </td>
                         <td className="py-2 px-3">
-                          {s.fuelType}
-                          {stale && (
-                            <span className="ml-1.5 text-[10px] uppercase tracking-wide text-amber-600">
-                              stale
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+                              style={{ backgroundColor: color }}
+                              aria-hidden="true"
+                            />
+                            <span className="text-[13px]">
+                              {GRADE_LABEL[s.fuelType] ?? s.fuelType}
                             </span>
-                          )}
+                            {stale && (
+                              <span className="text-[10px] uppercase tracking-wide text-amber-600 font-medium">
+                                stale
+                              </span>
+                            )}
+                          </div>
                         </td>
-                        <td className="py-2 px-3 text-right hidden sm:table-cell whitespace-nowrap tabular-nums">
-                          {peso(s.priceMin)}
+                        <td className="py-2 px-3 text-right whitespace-nowrap tabular-nums">
+                          <div className="font-semibold text-gray-900">
+                            {peso(s.priceAvg)}
+                          </div>
+                          <div className="text-[11px] text-gray-500">
+                            {priceRange(s)}
+                          </div>
                         </td>
-                        <td className="py-2 px-3 text-right font-medium whitespace-nowrap tabular-nums">
-                          {peso(s.priceAvg)}
-                        </td>
-                        <td className="py-2 px-3 text-right hidden sm:table-cell whitespace-nowrap tabular-nums">
-                          {peso(s.priceMax)}
-                        </td>
-                        <td className="py-2 px-3 text-right hidden md:table-cell tabular-nums">
+                        <td className="py-2 px-3 text-right hidden md:table-cell tabular-nums text-gray-600">
                           {s.stationCount}
                         </td>
                       </tr>
@@ -514,7 +497,7 @@ export default function FuelPricesSection() {
                   {filtered.length === 0 && (
                     <tr>
                       <td
-                        colSpan={6}
+                        colSpan={4}
                         className="py-8 text-center text-gray-500"
                       >
                         No snapshots for this fuel type in the selected range

--- a/src/data/transparency/fuel-prices.json
+++ b/src/data/transparency/fuel-prices.json
@@ -299,6 +299,24 @@
       ]
     },
     {
+      "id": "fp-2026-04-07-dslplus",
+      "date": "2026-04-07",
+      "fuelType": "Diesel Plus",
+      "priceMin": 140.8,
+      "priceAvg": 140.8,
+      "priceMax": 140.8,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 140.8,
+          "priceMax": 140.8
+        }
+      ],
+      "stale": true,
+      "staleSince": "2026-03-31"
+    },
+    {
       "id": "fp-2026-03-31-gas91",
       "date": "2026-03-31",
       "fuelType": "Gasoline RON 91",
@@ -847,6 +865,24 @@
           "priceMax": 86.14
         }
       ]
+    },
+    {
+      "id": "fp-2026-03-10-dslplus",
+      "date": "2026-03-10",
+      "fuelType": "Diesel Plus",
+      "priceMin": 60.99,
+      "priceAvg": 66.57,
+      "priceMax": 72.15,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 60.99,
+          "priceMax": 72.15
+        }
+      ],
+      "stale": true,
+      "staleSince": "2026-03-03"
     },
     {
       "id": "fp-2026-03-03-gas91",

--- a/src/data/transparency/fuel-prices.json
+++ b/src/data/transparency/fuel-prices.json
@@ -1,0 +1,589 @@
+{
+  "placeholder": true,
+  "snapshots": [
+    {
+      "id": "fp-2026-04-15-gas91",
+      "date": "2026-04-15",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 58.95,
+      "priceAvg": 60.4,
+      "priceMax": 62.1,
+      "stationCount": 24
+    },
+    {
+      "id": "fp-2026-04-15-gas95",
+      "date": "2026-04-15",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 62.1,
+      "priceAvg": 63.55,
+      "priceMax": 65.3,
+      "stationCount": 28
+    },
+    {
+      "id": "fp-2026-04-15-gas97",
+      "date": "2026-04-15",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 65.4,
+      "priceAvg": 66.9,
+      "priceMax": 68.8,
+      "stationCount": 19
+    },
+    {
+      "id": "fp-2026-04-15-dsl",
+      "date": "2026-04-15",
+      "fuelType": "Diesel",
+      "priceMin": 54.25,
+      "priceAvg": 55.8,
+      "priceMax": 57.6,
+      "stationCount": 28
+    },
+    {
+      "id": "fp-2026-04-15-krs",
+      "date": "2026-04-15",
+      "fuelType": "Kerosene",
+      "priceMin": 66.8,
+      "priceAvg": 68.1,
+      "priceMax": 69.9,
+      "stationCount": 12
+    },
+
+    {
+      "id": "fp-2026-04-08-gas91",
+      "date": "2026-04-08",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 59.3,
+      "priceAvg": 60.75,
+      "priceMax": 62.4,
+      "stationCount": 24
+    },
+    {
+      "id": "fp-2026-04-08-gas95",
+      "date": "2026-04-08",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 62.45,
+      "priceAvg": 63.9,
+      "priceMax": 65.6,
+      "stationCount": 28
+    },
+    {
+      "id": "fp-2026-04-08-gas97",
+      "date": "2026-04-08",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 65.75,
+      "priceAvg": 67.2,
+      "priceMax": 69.1,
+      "stationCount": 19
+    },
+    {
+      "id": "fp-2026-04-08-dsl",
+      "date": "2026-04-08",
+      "fuelType": "Diesel",
+      "priceMin": 54.6,
+      "priceAvg": 56.1,
+      "priceMax": 57.9,
+      "stationCount": 28
+    },
+    {
+      "id": "fp-2026-04-08-krs",
+      "date": "2026-04-08",
+      "fuelType": "Kerosene",
+      "priceMin": 67.1,
+      "priceAvg": 68.4,
+      "priceMax": 70.2,
+      "stationCount": 12
+    },
+
+    {
+      "id": "fp-2026-04-01-gas91",
+      "date": "2026-04-01",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 58.7,
+      "priceAvg": 60.15,
+      "priceMax": 61.8,
+      "stationCount": 24
+    },
+    {
+      "id": "fp-2026-04-01-gas95",
+      "date": "2026-04-01",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 61.85,
+      "priceAvg": 63.3,
+      "priceMax": 65.0,
+      "stationCount": 28
+    },
+    {
+      "id": "fp-2026-04-01-gas97",
+      "date": "2026-04-01",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 65.15,
+      "priceAvg": 66.6,
+      "priceMax": 68.5,
+      "stationCount": 19
+    },
+    {
+      "id": "fp-2026-04-01-dsl",
+      "date": "2026-04-01",
+      "fuelType": "Diesel",
+      "priceMin": 54.0,
+      "priceAvg": 55.5,
+      "priceMax": 57.3,
+      "stationCount": 28
+    },
+    {
+      "id": "fp-2026-04-01-krs",
+      "date": "2026-04-01",
+      "fuelType": "Kerosene",
+      "priceMin": 66.5,
+      "priceAvg": 67.8,
+      "priceMax": 69.6,
+      "stationCount": 12
+    },
+
+    {
+      "id": "fp-2026-03-25-gas91",
+      "date": "2026-03-25",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 58.35,
+      "priceAvg": 59.8,
+      "priceMax": 61.45,
+      "stationCount": 23
+    },
+    {
+      "id": "fp-2026-03-25-gas95",
+      "date": "2026-03-25",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 61.5,
+      "priceAvg": 62.95,
+      "priceMax": 64.65,
+      "stationCount": 27
+    },
+    {
+      "id": "fp-2026-03-25-gas97",
+      "date": "2026-03-25",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 64.8,
+      "priceAvg": 66.25,
+      "priceMax": 68.15,
+      "stationCount": 19
+    },
+    {
+      "id": "fp-2026-03-25-dsl",
+      "date": "2026-03-25",
+      "fuelType": "Diesel",
+      "priceMin": 53.7,
+      "priceAvg": 55.2,
+      "priceMax": 57.0,
+      "stationCount": 27
+    },
+    {
+      "id": "fp-2026-03-25-krs",
+      "date": "2026-03-25",
+      "fuelType": "Kerosene",
+      "priceMin": 66.2,
+      "priceAvg": 67.5,
+      "priceMax": 69.3,
+      "stationCount": 12
+    },
+
+    {
+      "id": "fp-2026-03-18-gas91",
+      "date": "2026-03-18",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 58.0,
+      "priceAvg": 59.45,
+      "priceMax": 61.1,
+      "stationCount": 23
+    },
+    {
+      "id": "fp-2026-03-18-gas95",
+      "date": "2026-03-18",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 61.15,
+      "priceAvg": 62.6,
+      "priceMax": 64.3,
+      "stationCount": 27
+    },
+    {
+      "id": "fp-2026-03-18-gas97",
+      "date": "2026-03-18",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 64.45,
+      "priceAvg": 65.9,
+      "priceMax": 67.8,
+      "stationCount": 18
+    },
+    {
+      "id": "fp-2026-03-18-dsl",
+      "date": "2026-03-18",
+      "fuelType": "Diesel",
+      "priceMin": 53.4,
+      "priceAvg": 54.9,
+      "priceMax": 56.7,
+      "stationCount": 27
+    },
+    {
+      "id": "fp-2026-03-18-krs",
+      "date": "2026-03-18",
+      "fuelType": "Kerosene",
+      "priceMin": 65.9,
+      "priceAvg": 67.2,
+      "priceMax": 69.0,
+      "stationCount": 11
+    },
+
+    {
+      "id": "fp-2026-03-11-gas91",
+      "date": "2026-03-11",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 57.7,
+      "priceAvg": 59.1,
+      "priceMax": 60.75,
+      "stationCount": 23
+    },
+    {
+      "id": "fp-2026-03-11-gas95",
+      "date": "2026-03-11",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 60.85,
+      "priceAvg": 62.25,
+      "priceMax": 63.95,
+      "stationCount": 27
+    },
+    {
+      "id": "fp-2026-03-11-gas97",
+      "date": "2026-03-11",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 64.1,
+      "priceAvg": 65.55,
+      "priceMax": 67.45,
+      "stationCount": 18
+    },
+    {
+      "id": "fp-2026-03-11-dsl",
+      "date": "2026-03-11",
+      "fuelType": "Diesel",
+      "priceMin": 53.1,
+      "priceAvg": 54.6,
+      "priceMax": 56.4,
+      "stationCount": 27
+    },
+    {
+      "id": "fp-2026-03-11-krs",
+      "date": "2026-03-11",
+      "fuelType": "Kerosene",
+      "priceMin": 65.6,
+      "priceAvg": 66.9,
+      "priceMax": 68.7,
+      "stationCount": 11
+    },
+
+    {
+      "id": "fp-2026-03-04-gas91",
+      "date": "2026-03-04",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 57.95,
+      "priceAvg": 59.35,
+      "priceMax": 61.0,
+      "stationCount": 22
+    },
+    {
+      "id": "fp-2026-03-04-gas95",
+      "date": "2026-03-04",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 61.1,
+      "priceAvg": 62.5,
+      "priceMax": 64.2,
+      "stationCount": 26
+    },
+    {
+      "id": "fp-2026-03-04-gas97",
+      "date": "2026-03-04",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 64.35,
+      "priceAvg": 65.8,
+      "priceMax": 67.7,
+      "stationCount": 18
+    },
+    {
+      "id": "fp-2026-03-04-dsl",
+      "date": "2026-03-04",
+      "fuelType": "Diesel",
+      "priceMin": 53.35,
+      "priceAvg": 54.85,
+      "priceMax": 56.65,
+      "stationCount": 26
+    },
+    {
+      "id": "fp-2026-03-04-krs",
+      "date": "2026-03-04",
+      "fuelType": "Kerosene",
+      "priceMin": 65.8,
+      "priceAvg": 67.1,
+      "priceMax": 68.9,
+      "stationCount": 11
+    },
+
+    {
+      "id": "fp-2026-02-25-gas91",
+      "date": "2026-02-25",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 58.4,
+      "priceAvg": 59.8,
+      "priceMax": 61.45,
+      "stationCount": 22
+    },
+    {
+      "id": "fp-2026-02-25-gas95",
+      "date": "2026-02-25",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 61.55,
+      "priceAvg": 62.95,
+      "priceMax": 64.65,
+      "stationCount": 26
+    },
+    {
+      "id": "fp-2026-02-25-gas97",
+      "date": "2026-02-25",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 64.8,
+      "priceAvg": 66.25,
+      "priceMax": 68.15,
+      "stationCount": 18
+    },
+    {
+      "id": "fp-2026-02-25-dsl",
+      "date": "2026-02-25",
+      "fuelType": "Diesel",
+      "priceMin": 53.8,
+      "priceAvg": 55.3,
+      "priceMax": 57.1,
+      "stationCount": 26
+    },
+    {
+      "id": "fp-2026-02-25-krs",
+      "date": "2026-02-25",
+      "fuelType": "Kerosene",
+      "priceMin": 66.3,
+      "priceAvg": 67.6,
+      "priceMax": 69.4,
+      "stationCount": 11
+    },
+
+    {
+      "id": "fp-2026-02-18-gas91",
+      "date": "2026-02-18",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 58.7,
+      "priceAvg": 60.1,
+      "priceMax": 61.75,
+      "stationCount": 22
+    },
+    {
+      "id": "fp-2026-02-18-gas95",
+      "date": "2026-02-18",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 61.85,
+      "priceAvg": 63.25,
+      "priceMax": 64.95,
+      "stationCount": 25
+    },
+    {
+      "id": "fp-2026-02-18-gas97",
+      "date": "2026-02-18",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 65.1,
+      "priceAvg": 66.55,
+      "priceMax": 68.45,
+      "stationCount": 17
+    },
+    {
+      "id": "fp-2026-02-18-dsl",
+      "date": "2026-02-18",
+      "fuelType": "Diesel",
+      "priceMin": 54.05,
+      "priceAvg": 55.55,
+      "priceMax": 57.35,
+      "stationCount": 25
+    },
+    {
+      "id": "fp-2026-02-18-krs",
+      "date": "2026-02-18",
+      "fuelType": "Kerosene",
+      "priceMin": 66.55,
+      "priceAvg": 67.85,
+      "priceMax": 69.65,
+      "stationCount": 11
+    },
+
+    {
+      "id": "fp-2026-02-11-gas91",
+      "date": "2026-02-11",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 59.1,
+      "priceAvg": 60.55,
+      "priceMax": 62.2,
+      "stationCount": 21
+    },
+    {
+      "id": "fp-2026-02-11-gas95",
+      "date": "2026-02-11",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 62.3,
+      "priceAvg": 63.75,
+      "priceMax": 65.45,
+      "stationCount": 25
+    },
+    {
+      "id": "fp-2026-02-11-gas97",
+      "date": "2026-02-11",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 65.55,
+      "priceAvg": 67.0,
+      "priceMax": 68.9,
+      "stationCount": 17
+    },
+    {
+      "id": "fp-2026-02-11-dsl",
+      "date": "2026-02-11",
+      "fuelType": "Diesel",
+      "priceMin": 54.45,
+      "priceAvg": 55.95,
+      "priceMax": 57.75,
+      "stationCount": 25
+    },
+    {
+      "id": "fp-2026-02-11-krs",
+      "date": "2026-02-11",
+      "fuelType": "Kerosene",
+      "priceMin": 66.9,
+      "priceAvg": 68.2,
+      "priceMax": 70.0,
+      "stationCount": 10
+    },
+
+    {
+      "id": "fp-2026-02-04-gas91",
+      "date": "2026-02-04",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 59.4,
+      "priceAvg": 60.85,
+      "priceMax": 62.5,
+      "stationCount": 21
+    },
+    {
+      "id": "fp-2026-02-04-gas95",
+      "date": "2026-02-04",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 62.6,
+      "priceAvg": 64.05,
+      "priceMax": 65.75,
+      "stationCount": 25
+    },
+    {
+      "id": "fp-2026-02-04-gas97",
+      "date": "2026-02-04",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 65.85,
+      "priceAvg": 67.3,
+      "priceMax": 69.2,
+      "stationCount": 17
+    },
+    {
+      "id": "fp-2026-02-04-dsl",
+      "date": "2026-02-04",
+      "fuelType": "Diesel",
+      "priceMin": 54.75,
+      "priceAvg": 56.25,
+      "priceMax": 58.05,
+      "stationCount": 25
+    },
+    {
+      "id": "fp-2026-02-04-krs",
+      "date": "2026-02-04",
+      "fuelType": "Kerosene",
+      "priceMin": 67.2,
+      "priceAvg": 68.5,
+      "priceMax": 70.3,
+      "stationCount": 10
+    },
+
+    {
+      "id": "fp-2026-01-28-gas91",
+      "date": "2026-01-28",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 59.8,
+      "priceAvg": 61.25,
+      "priceMax": 62.9,
+      "stationCount": 21
+    },
+    {
+      "id": "fp-2026-01-28-gas95",
+      "date": "2026-01-28",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 62.95,
+      "priceAvg": 64.4,
+      "priceMax": 66.1,
+      "stationCount": 24
+    },
+    {
+      "id": "fp-2026-01-28-gas97",
+      "date": "2026-01-28",
+      "fuelType": "Gasoline RON 97",
+      "priceMin": 66.2,
+      "priceAvg": 67.65,
+      "priceMax": 69.55,
+      "stationCount": 16
+    },
+    {
+      "id": "fp-2026-01-28-dsl",
+      "date": "2026-01-28",
+      "fuelType": "Diesel",
+      "priceMin": 55.1,
+      "priceAvg": 56.6,
+      "priceMax": 58.4,
+      "stationCount": 24
+    },
+    {
+      "id": "fp-2026-01-28-krs",
+      "date": "2026-01-28",
+      "fuelType": "Kerosene",
+      "priceMin": 67.55,
+      "priceAvg": 68.85,
+      "priceMax": 70.65,
+      "stationCount": 10
+    }
+  ],
+  "filters": {
+    "fuelTypes": [
+      "Gasoline RON 91",
+      "Gasoline RON 95",
+      "Gasoline RON 97",
+      "Diesel",
+      "Kerosene"
+    ],
+    "weeks": [
+      "2026-04-15",
+      "2026-04-08",
+      "2026-04-01",
+      "2026-03-25",
+      "2026-03-18",
+      "2026-03-11",
+      "2026-03-04",
+      "2026-02-25",
+      "2026-02-18",
+      "2026-02-11",
+      "2026-02-04",
+      "2026-01-28"
+    ]
+  },
+  "stats": {
+    "latestWeek": "2026-04-15",
+    "weeksTracked": 12,
+    "fuelTypes": 5,
+    "stationsSurveyed": 28
+  },
+  "source": "DOE Oil Industry Management Bureau",
+  "sourceUrl": "https://www.doe.gov.ph/oil-monitor",
+  "contributor": "Shiro_Oni",
+  "lastUpdated": "2026-04-15"
+}

--- a/src/data/transparency/fuel-prices.json
+++ b/src/data/transparency/fuel-prices.json
@@ -1,589 +1,2162 @@
 {
-  "placeholder": true,
+  "placeholder": false,
   "snapshots": [
     {
-      "id": "fp-2026-04-15-gas91",
-      "date": "2026-04-15",
+      "id": "fp-2026-04-14-gas91",
+      "date": "2026-04-14",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 58.95,
-      "priceAvg": 60.4,
-      "priceMax": 62.1,
-      "stationCount": 24
+      "priceMin": 82.4,
+      "priceAvg": 87.94,
+      "priceMax": 105.2,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 85.6,
+          "priceMax": 86.5
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 82.4,
+          "priceMax": 96.2
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 85.0,
+          "priceMax": 92.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 83.4,
+          "priceMax": 88.1
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 83.6,
+          "priceMax": 83.6
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 86.8,
+          "priceMax": 105.2
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 86.4,
+          "priceMax": 86.4
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-15-gas95",
-      "date": "2026-04-15",
+      "id": "fp-2026-04-14-gas95",
+      "date": "2026-04-14",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 62.1,
-      "priceAvg": 63.55,
-      "priceMax": 65.3,
-      "stationCount": 28
+      "priceMin": 84.4,
+      "priceAvg": 90.75,
+      "priceMax": 109.0,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 86.6,
+          "priceMax": 89.5
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 84.4,
+          "priceMax": 96.2
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 85.7,
+          "priceMax": 92.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 84.5,
+          "priceMax": 90.1
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 85.6,
+          "priceMax": 85.6
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 109.0,
+          "priceMax": 109.0
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 85.9,
+          "priceMax": 85.9
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-15-gas97",
-      "date": "2026-04-15",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 65.4,
-      "priceAvg": 66.9,
-      "priceMax": 68.8,
-      "stationCount": 19
-    },
-    {
-      "id": "fp-2026-04-15-dsl",
-      "date": "2026-04-15",
+      "id": "fp-2026-04-14-dsl",
+      "date": "2026-04-14",
       "fuelType": "Diesel",
-      "priceMin": 54.25,
-      "priceAvg": 55.8,
-      "priceMax": 57.6,
-      "stationCount": 28
+      "priceMin": 114.1,
+      "priceAvg": 119.61,
+      "priceMax": 152.9,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 115.1,
+          "priceMax": 116.5
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 114.4,
+          "priceMax": 119.7
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 119.0,
+          "priceMax": 125.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 115.2,
+          "priceMax": 115.6
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 114.1,
+          "priceMax": 114.1
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 117.5,
+          "priceMax": 152.9
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 117.5,
+          "priceMax": 117.5
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-15-krs",
-      "date": "2026-04-15",
-      "fuelType": "Kerosene",
-      "priceMin": 66.8,
-      "priceAvg": 68.1,
-      "priceMax": 69.9,
-      "stationCount": 12
+      "id": "fp-2026-04-14-dslplus",
+      "date": "2026-04-14",
+      "fuelType": "Diesel Plus",
+      "priceMin": 131.2,
+      "priceAvg": 146.15,
+      "priceMax": 161.1,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 131.2,
+          "priceMax": 161.1
+        }
+      ]
     },
-
     {
-      "id": "fp-2026-04-08-gas91",
-      "date": "2026-04-08",
+      "id": "fp-2026-04-07-gas91",
+      "date": "2026-04-07",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 59.3,
-      "priceAvg": 60.75,
-      "priceMax": 62.4,
-      "stationCount": 24
+      "priceMin": 80.05,
+      "priceAvg": 91.85,
+      "priceMax": 101.4,
+      "stationCount": 8,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 88.7,
+          "priceMax": 101.4
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 91.5,
+          "priceMax": 98.0
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 80.05,
+          "priceMax": 95.1
+        },
+        {
+          "station": "JETTI",
+          "priceMin": 92.4,
+          "priceMax": 92.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 89.0,
+          "priceMax": 94.6
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 84.9,
+          "priceMax": 84.9
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 96.3,
+          "priceMax": 96.3
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 92.0,
+          "priceMax": 92.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-08-gas95",
-      "date": "2026-04-08",
+      "id": "fp-2026-04-07-gas95",
+      "date": "2026-04-07",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 62.45,
-      "priceAvg": 63.9,
-      "priceMax": 65.6,
-      "stationCount": 28
+      "priceMin": 85.6,
+      "priceAvg": 92.83,
+      "priceMax": 102.4,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 89.3,
+          "priceMax": 102.4
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 92.6,
+          "priceMax": 98.5
+        },
+        {
+          "station": "JETTI",
+          "priceMin": 93.4,
+          "priceMax": 93.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 92.6,
+          "priceMax": 94.5
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 85.6,
+          "priceMax": 85.6
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 93.0,
+          "priceMax": 93.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-08-gas97",
-      "date": "2026-04-08",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 65.75,
-      "priceAvg": 67.2,
-      "priceMax": 69.1,
-      "stationCount": 19
-    },
-    {
-      "id": "fp-2026-04-08-dsl",
-      "date": "2026-04-08",
+      "id": "fp-2026-04-07-dsl",
+      "date": "2026-04-07",
       "fuelType": "Diesel",
-      "priceMin": 54.6,
-      "priceAvg": 56.1,
-      "priceMax": 57.9,
-      "stationCount": 28
+      "priceMin": 127.0,
+      "priceAvg": 137.88,
+      "priceMax": 151.3,
+      "stationCount": 8,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 137.0,
+          "priceMax": 146.3
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 135.0,
+          "priceMax": 138.4
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 128.8,
+          "priceMax": 146.95
+        },
+        {
+          "station": "JETTI",
+          "priceMin": 135.1,
+          "priceMax": 135.1
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 136.0,
+          "priceMax": 136.8
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 137.0,
+          "priceMax": 137.0
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 151.3,
+          "priceMax": 151.3
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 127.0,
+          "priceMax": 127.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-08-krs",
-      "date": "2026-04-08",
-      "fuelType": "Kerosene",
-      "priceMin": 67.1,
-      "priceAvg": 68.4,
-      "priceMax": 70.2,
-      "stationCount": 12
-    },
-
-    {
-      "id": "fp-2026-04-01-gas91",
-      "date": "2026-04-01",
+      "id": "fp-2026-03-31-gas91",
+      "date": "2026-03-31",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 58.7,
-      "priceAvg": 60.15,
-      "priceMax": 61.8,
-      "stationCount": 24
+      "priceMin": 88.6,
+      "priceAvg": 95.18,
+      "priceMax": 99.95,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 96.55,
+          "priceMax": 99.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 92.3,
+          "priceMax": 97.8
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 93.0,
+          "priceMax": 95.98
+        },
+        {
+          "station": "JETTI",
+          "priceMin": 92.4,
+          "priceMax": 92.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 88.6,
+          "priceMax": 95.3
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 96.0,
+          "priceMax": 96.0
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 96.55,
+          "priceMax": 99.7
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-01-gas95",
-      "date": "2026-04-01",
+      "id": "fp-2026-03-31-gas95",
+      "date": "2026-03-31",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 61.85,
-      "priceAvg": 63.3,
-      "priceMax": 65.0,
-      "stationCount": 28
+      "priceMin": 90.6,
+      "priceAvg": 96.01,
+      "priceMax": 100.95,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 98.55,
+          "priceMax": 100.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 94.3,
+          "priceMax": 98.3
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 94.4,
+          "priceMax": 96.9
+        },
+        {
+          "station": "JETTI",
+          "priceMin": 93.4,
+          "priceMax": 93.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 90.6,
+          "priceMax": 96.3
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 96.0,
+          "priceMax": 96.0
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 97.55,
+          "priceMax": 97.55
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-01-gas97",
-      "date": "2026-04-01",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 65.15,
-      "priceAvg": 66.6,
-      "priceMax": 68.5,
-      "stationCount": 19
-    },
-    {
-      "id": "fp-2026-04-01-dsl",
-      "date": "2026-04-01",
+      "id": "fp-2026-03-31-dsl",
+      "date": "2026-03-31",
       "fuelType": "Diesel",
-      "priceMin": 54.0,
-      "priceAvg": 55.5,
-      "priceMax": 57.3,
-      "stationCount": 28
+      "priceMin": 117.0,
+      "priceAvg": 127.92,
+      "priceMax": 135.8,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 130.45,
+          "priceMax": 131.8
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 123.8,
+          "priceMax": 131.8
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 120.95,
+          "priceMax": 129.7
+        },
+        {
+          "station": "JETTI",
+          "priceMin": 135.1,
+          "priceMax": 135.1
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 117.0,
+          "priceMax": 125.15
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 122.0,
+          "priceMax": 122.0
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 130.25,
+          "priceMax": 135.8
+        }
+      ]
     },
     {
-      "id": "fp-2026-04-01-krs",
-      "date": "2026-04-01",
-      "fuelType": "Kerosene",
-      "priceMin": 66.5,
-      "priceAvg": 67.8,
-      "priceMax": 69.6,
-      "stationCount": 12
+      "id": "fp-2026-03-31-dslplus",
+      "date": "2026-03-31",
+      "fuelType": "Diesel Plus",
+      "priceMin": 140.8,
+      "priceAvg": 140.8,
+      "priceMax": 140.8,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 140.8,
+          "priceMax": 140.8
+        }
+      ]
     },
-
     {
-      "id": "fp-2026-03-25-gas91",
-      "date": "2026-03-25",
+      "id": "fp-2026-03-24-gas91",
+      "date": "2026-03-24",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 58.35,
-      "priceAvg": 59.8,
-      "priceMax": 61.45,
-      "stationCount": 23
+      "priceMin": 87.9,
+      "priceAvg": 94.5,
+      "priceMax": 98.0,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 94.35,
+          "priceMax": 97.1
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 87.9,
+          "priceMax": 96.9
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 90.5,
+          "priceMax": 93.9
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 91.5,
+          "priceMax": 94.2
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 96.5,
+          "priceMax": 96.5
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 97.6,
+          "priceMax": 98.0
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 94.0,
+          "priceMax": 94.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-03-25-gas95",
-      "date": "2026-03-25",
+      "id": "fp-2026-03-24-gas95",
+      "date": "2026-03-24",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 61.5,
-      "priceAvg": 62.95,
-      "priceMax": 64.65,
-      "stationCount": 27
+      "priceMin": 88.0,
+      "priceAvg": 96.3,
+      "priceMax": 105.2,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 95.35,
+          "priceMax": 98.1
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 88.0,
+          "priceMax": 96.9
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 92.7,
+          "priceMax": 96.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 92.5,
+          "priceMax": 96.2
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 96.0,
+          "priceMax": 96.0
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 105.2,
+          "priceMax": 105.2
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 95.0,
+          "priceMax": 95.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-03-25-gas97",
-      "date": "2026-03-25",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 64.8,
-      "priceAvg": 66.25,
-      "priceMax": 68.15,
-      "stationCount": 19
-    },
-    {
-      "id": "fp-2026-03-25-dsl",
-      "date": "2026-03-25",
+      "id": "fp-2026-03-24-dsl",
+      "date": "2026-03-24",
       "fuelType": "Diesel",
-      "priceMin": 53.7,
-      "priceAvg": 55.2,
-      "priceMax": 57.0,
-      "stationCount": 27
+      "priceMin": 110.9,
+      "priceAvg": 118.76,
+      "priceMax": 125.7,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 120.9,
+          "priceMax": 123.5
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 110.9,
+          "priceMax": 121.4
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 115.0,
+          "priceMax": 120.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 118.8,
+          "priceMax": 119.1
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 112.0,
+          "priceMax": 112.0
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 125.3,
+          "priceMax": 125.7
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 119.0,
+          "priceMax": 119.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-03-25-krs",
-      "date": "2026-03-25",
-      "fuelType": "Kerosene",
-      "priceMin": 66.2,
-      "priceAvg": 67.5,
-      "priceMax": 69.3,
-      "stationCount": 12
+      "id": "fp-2026-03-24-dslplus",
+      "date": "2026-03-24",
+      "fuelType": "Diesel Plus",
+      "priceMin": 137.7,
+      "priceAvg": 137.7,
+      "priceMax": 137.7,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 137.7,
+          "priceMax": 137.7
+        }
+      ]
     },
-
     {
-      "id": "fp-2026-03-18-gas91",
-      "date": "2026-03-18",
+      "id": "fp-2026-03-17-gas91",
+      "date": "2026-03-17",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 58.0,
-      "priceAvg": 59.45,
-      "priceMax": 61.1,
-      "stationCount": 23
+      "priceMin": 75.85,
+      "priceAvg": 81.51,
+      "priceMax": 86.6,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 78.5,
+          "priceMax": 78.5
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 75.85,
+          "priceMax": 82.3
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 82.35,
+          "priceMax": 82.8
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 78.4,
+          "priceMax": 81.7
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 78.1,
+          "priceMax": 86.6
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 86.5,
+          "priceMax": 86.5
+        }
+      ]
     },
     {
-      "id": "fp-2026-03-18-gas95",
-      "date": "2026-03-18",
+      "id": "fp-2026-03-17-gas95",
+      "date": "2026-03-17",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 61.15,
-      "priceAvg": 62.6,
-      "priceMax": 64.3,
-      "stationCount": 27
+      "priceMin": 76.4,
+      "priceAvg": 82.02,
+      "priceMax": 86.6,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 79.5,
+          "priceMax": 79.5
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 76.4,
+          "priceMax": 82.8
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 82.55,
+          "priceMax": 82.8
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 79.4,
+          "priceMax": 82.7
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 79.0,
+          "priceMax": 86.6
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 86.5,
+          "priceMax": 86.5
+        }
+      ]
     },
     {
-      "id": "fp-2026-03-18-gas97",
-      "date": "2026-03-18",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 64.45,
-      "priceAvg": 65.9,
-      "priceMax": 67.8,
-      "stationCount": 18
-    },
-    {
-      "id": "fp-2026-03-18-dsl",
-      "date": "2026-03-18",
+      "id": "fp-2026-03-17-dsl",
+      "date": "2026-03-17",
       "fuelType": "Diesel",
-      "priceMin": 53.4,
-      "priceAvg": 54.9,
-      "priceMax": 56.7,
-      "stationCount": 27
+      "priceMin": 92.46,
+      "priceAvg": 97.84,
+      "priceMax": 99.6,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 97.3,
+          "priceMax": 97.3
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 92.46,
+          "priceMax": 99.4
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 98.8,
+          "priceMax": 98.95
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 97.2,
+          "priceMax": 99.45
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 94.6,
+          "priceMax": 99.6
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 99.5,
+          "priceMax": 99.5
+        }
+      ]
     },
     {
-      "id": "fp-2026-03-18-krs",
-      "date": "2026-03-18",
-      "fuelType": "Kerosene",
-      "priceMin": 65.9,
-      "priceAvg": 67.2,
-      "priceMax": 69.0,
-      "stationCount": 11
+      "id": "fp-2026-03-17-dslplus",
+      "date": "2026-03-17",
+      "fuelType": "Diesel Plus",
+      "priceMin": 96.6,
+      "priceAvg": 96.75,
+      "priceMax": 96.9,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 96.6,
+          "priceMax": 96.9
+        }
+      ]
     },
-
     {
-      "id": "fp-2026-03-11-gas91",
-      "date": "2026-03-11",
+      "id": "fp-2026-03-10-gas91",
+      "date": "2026-03-10",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 57.7,
-      "priceAvg": 59.1,
-      "priceMax": 60.75,
-      "stationCount": 23
-    },
-    {
-      "id": "fp-2026-03-11-gas95",
-      "date": "2026-03-11",
-      "fuelType": "Gasoline RON 95",
-      "priceMin": 60.85,
-      "priceAvg": 62.25,
-      "priceMax": 63.95,
-      "stationCount": 27
-    },
-    {
-      "id": "fp-2026-03-11-gas97",
-      "date": "2026-03-11",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 64.1,
-      "priceAvg": 65.55,
-      "priceMax": 67.45,
-      "stationCount": 18
-    },
-    {
-      "id": "fp-2026-03-11-dsl",
-      "date": "2026-03-11",
-      "fuelType": "Diesel",
-      "priceMin": 53.1,
-      "priceAvg": 54.6,
-      "priceMax": 56.4,
-      "stationCount": 27
-    },
-    {
-      "id": "fp-2026-03-11-krs",
-      "date": "2026-03-11",
-      "fuelType": "Kerosene",
-      "priceMin": 65.6,
-      "priceAvg": 66.9,
-      "priceMax": 68.7,
-      "stationCount": 11
-    },
-
-    {
-      "id": "fp-2026-03-04-gas91",
-      "date": "2026-03-04",
-      "fuelType": "Gasoline RON 91",
-      "priceMin": 57.95,
-      "priceAvg": 59.35,
-      "priceMax": 61.0,
-      "stationCount": 22
-    },
-    {
-      "id": "fp-2026-03-04-gas95",
-      "date": "2026-03-04",
-      "fuelType": "Gasoline RON 95",
-      "priceMin": 61.1,
-      "priceAvg": 62.5,
-      "priceMax": 64.2,
-      "stationCount": 26
-    },
-    {
-      "id": "fp-2026-03-04-gas97",
-      "date": "2026-03-04",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 64.35,
-      "priceAvg": 65.8,
-      "priceMax": 67.7,
-      "stationCount": 18
-    },
-    {
-      "id": "fp-2026-03-04-dsl",
-      "date": "2026-03-04",
-      "fuelType": "Diesel",
-      "priceMin": 53.35,
-      "priceAvg": 54.85,
-      "priceMax": 56.65,
-      "stationCount": 26
-    },
-    {
-      "id": "fp-2026-03-04-krs",
-      "date": "2026-03-04",
-      "fuelType": "Kerosene",
-      "priceMin": 65.8,
-      "priceAvg": 67.1,
-      "priceMax": 68.9,
-      "stationCount": 11
-    },
-
-    {
-      "id": "fp-2026-02-25-gas91",
-      "date": "2026-02-25",
-      "fuelType": "Gasoline RON 91",
-      "priceMin": 58.4,
-      "priceAvg": 59.8,
-      "priceMax": 61.45,
-      "stationCount": 22
-    },
-    {
-      "id": "fp-2026-02-25-gas95",
-      "date": "2026-02-25",
-      "fuelType": "Gasoline RON 95",
-      "priceMin": 61.55,
-      "priceAvg": 62.95,
-      "priceMax": 64.65,
-      "stationCount": 26
-    },
-    {
-      "id": "fp-2026-02-25-gas97",
-      "date": "2026-02-25",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 64.8,
-      "priceAvg": 66.25,
-      "priceMax": 68.15,
-      "stationCount": 18
-    },
-    {
-      "id": "fp-2026-02-25-dsl",
-      "date": "2026-02-25",
-      "fuelType": "Diesel",
-      "priceMin": 53.8,
-      "priceAvg": 55.3,
-      "priceMax": 57.1,
-      "stationCount": 26
-    },
-    {
-      "id": "fp-2026-02-25-krs",
-      "date": "2026-02-25",
-      "fuelType": "Kerosene",
-      "priceMin": 66.3,
-      "priceAvg": 67.6,
-      "priceMax": 69.4,
-      "stationCount": 11
-    },
-
-    {
-      "id": "fp-2026-02-18-gas91",
-      "date": "2026-02-18",
-      "fuelType": "Gasoline RON 91",
-      "priceMin": 58.7,
-      "priceAvg": 60.1,
-      "priceMax": 61.75,
-      "stationCount": 22
-    },
-    {
-      "id": "fp-2026-02-18-gas95",
-      "date": "2026-02-18",
-      "fuelType": "Gasoline RON 95",
-      "priceMin": 61.85,
-      "priceAvg": 63.25,
-      "priceMax": 64.95,
-      "stationCount": 25
-    },
-    {
-      "id": "fp-2026-02-18-gas97",
-      "date": "2026-02-18",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 65.1,
-      "priceAvg": 66.55,
-      "priceMax": 68.45,
-      "stationCount": 17
-    },
-    {
-      "id": "fp-2026-02-18-dsl",
-      "date": "2026-02-18",
-      "fuelType": "Diesel",
-      "priceMin": 54.05,
-      "priceAvg": 55.55,
-      "priceMax": 57.35,
-      "stationCount": 25
-    },
-    {
-      "id": "fp-2026-02-18-krs",
-      "date": "2026-02-18",
-      "fuelType": "Kerosene",
-      "priceMin": 66.55,
-      "priceAvg": 67.85,
-      "priceMax": 69.65,
-      "stationCount": 11
-    },
-
-    {
-      "id": "fp-2026-02-11-gas91",
-      "date": "2026-02-11",
-      "fuelType": "Gasoline RON 91",
-      "priceMin": 59.1,
-      "priceAvg": 60.55,
-      "priceMax": 62.2,
-      "stationCount": 21
-    },
-    {
-      "id": "fp-2026-02-11-gas95",
-      "date": "2026-02-11",
-      "fuelType": "Gasoline RON 95",
-      "priceMin": 62.3,
-      "priceAvg": 63.75,
-      "priceMax": 65.45,
-      "stationCount": 25
-    },
-    {
-      "id": "fp-2026-02-11-gas97",
-      "date": "2026-02-11",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 65.55,
-      "priceAvg": 67.0,
-      "priceMax": 68.9,
-      "stationCount": 17
-    },
-    {
-      "id": "fp-2026-02-11-dsl",
-      "date": "2026-02-11",
-      "fuelType": "Diesel",
-      "priceMin": 54.45,
-      "priceAvg": 55.95,
-      "priceMax": 57.75,
-      "stationCount": 25
-    },
-    {
-      "id": "fp-2026-02-11-krs",
-      "date": "2026-02-11",
-      "fuelType": "Kerosene",
-      "priceMin": 66.9,
-      "priceAvg": 68.2,
+      "priceMin": 64.0,
+      "priceAvg": 67.63,
       "priceMax": 70.0,
-      "stationCount": 10
+      "stationCount": 4,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 68.45,
+          "priceMax": 68.45
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 65.35,
+          "priceMax": 70.0
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 69.85,
+          "priceMax": 69.85
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 64.0,
+          "priceMax": 65.1
+        }
+      ]
     },
-
     {
-      "id": "fp-2026-02-04-gas91",
-      "date": "2026-02-04",
-      "fuelType": "Gasoline RON 91",
-      "priceMin": 59.4,
-      "priceAvg": 60.85,
-      "priceMax": 62.5,
-      "stationCount": 21
-    },
-    {
-      "id": "fp-2026-02-04-gas95",
-      "date": "2026-02-04",
+      "id": "fp-2026-03-10-gas95",
+      "date": "2026-03-10",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 62.6,
-      "priceAvg": 64.05,
-      "priceMax": 65.75,
-      "stationCount": 25
+      "priceMin": 65.3,
+      "priceAvg": 68.59,
+      "priceMax": 70.5,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 68.95,
+          "priceMax": 68.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 65.9,
+          "priceMax": 70.5
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 69.85,
+          "priceMax": 69.85
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 65.3,
+          "priceMax": 66.1
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 70.25,
+          "priceMax": 70.25
+        }
+      ]
     },
     {
-      "id": "fp-2026-02-04-gas97",
-      "date": "2026-02-04",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 65.85,
-      "priceAvg": 67.3,
+      "id": "fp-2026-03-10-dsl",
+      "date": "2026-03-10",
+      "fuelType": "Diesel",
+      "priceMin": 71.6,
+      "priceAvg": 79.05,
+      "priceMax": 86.14,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 77.05,
+          "priceMax": 77.05
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 78.3,
+          "priceMax": 81.1
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 79.0,
+          "priceMax": 79.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 71.6,
+          "priceMax": 75.1
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 86.14,
+          "priceMax": 86.14
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-03-03-gas91",
+      "date": "2026-03-03",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 53.02,
+      "priceAvg": 59.53,
+      "priceMax": 65.0,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 58.25,
+          "priceMax": 61.9
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 53.02,
+          "priceMax": 57.29
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 55.01,
+          "priceMax": 63.2
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.9,
+          "priceMax": 59.4
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 57.5,
+          "priceMax": 61.89
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 65.0,
+          "priceMax": 65.0
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-03-03-gas95",
+      "date": "2026-03-03",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 54.02,
+      "priceAvg": 60.8,
       "priceMax": 69.2,
-      "stationCount": 17
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 59.25,
+          "priceMax": 62.9
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 54.02,
+          "priceMax": 57.79
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 56.0,
+          "priceMax": 63.7
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 57.9,
+          "priceMax": 60.4
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.5,
+          "priceMax": 69.2
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 65.0,
+          "priceMax": 65.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-02-04-dsl",
-      "date": "2026-02-04",
+      "id": "fp-2026-03-03-dsl",
+      "date": "2026-03-03",
       "fuelType": "Diesel",
-      "priceMin": 54.75,
-      "priceAvg": 56.25,
-      "priceMax": 58.05,
-      "stationCount": 25
+      "priceMin": 53.6,
+      "priceAvg": 62.08,
+      "priceMax": 78.35,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 58.4,
+          "priceMax": 62.0
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 53.6,
+          "priceMax": 56.09
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 56.69,
+          "priceMax": 78.35
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 57.0,
+          "priceMax": 59.95
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.99,
+          "priceMax": 63.84
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 70.0,
+          "priceMax": 70.0
+        }
+      ]
     },
     {
-      "id": "fp-2026-02-04-krs",
-      "date": "2026-02-04",
-      "fuelType": "Kerosene",
-      "priceMin": 67.2,
-      "priceAvg": 68.5,
-      "priceMax": 70.3,
-      "stationCount": 10
+      "id": "fp-2026-03-03-dslplus",
+      "date": "2026-03-03",
+      "fuelType": "Diesel Plus",
+      "priceMin": 60.99,
+      "priceAvg": 66.57,
+      "priceMax": 72.15,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 60.99,
+          "priceMax": 72.15
+        }
+      ]
     },
-
     {
-      "id": "fp-2026-01-28-gas91",
-      "date": "2026-01-28",
+      "id": "fp-2026-02-24-gas91",
+      "date": "2026-02-24",
       "fuelType": "Gasoline RON 91",
-      "priceMin": 59.8,
-      "priceAvg": 61.25,
-      "priceMax": 62.9,
-      "stationCount": 21
+      "priceMin": 51.8,
+      "priceAvg": 56.44,
+      "priceMax": 59.99,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.35,
+          "priceMax": 58.3
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.95,
+          "priceMax": 54.89
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.8,
+          "priceMax": 58.9
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.0,
+          "priceMax": 57.5
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 59.7,
+          "priceMax": 59.99
+        }
+      ]
     },
     {
-      "id": "fp-2026-01-28-gas95",
-      "date": "2026-01-28",
+      "id": "fp-2026-02-24-gas95",
+      "date": "2026-02-24",
       "fuelType": "Gasoline RON 95",
-      "priceMin": 62.95,
-      "priceAvg": 64.4,
-      "priceMax": 66.1,
-      "stationCount": 24
+      "priceMin": 52.05,
+      "priceAvg": 58.62,
+      "priceMax": 67.89,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.35,
+          "priceMax": 59.3
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.95,
+          "priceMax": 55.39
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 52.05,
+          "priceMax": 59.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.0,
+          "priceMax": 58.5
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 67.3,
+          "priceMax": 67.89
+        }
+      ]
     },
     {
-      "id": "fp-2026-01-28-gas97",
-      "date": "2026-01-28",
-      "fuelType": "Gasoline RON 97",
-      "priceMin": 66.2,
-      "priceAvg": 67.65,
-      "priceMax": 69.55,
-      "stationCount": 16
-    },
-    {
-      "id": "fp-2026-01-28-dsl",
-      "date": "2026-01-28",
+      "id": "fp-2026-02-24-dsl",
+      "date": "2026-02-24",
       "fuelType": "Diesel",
-      "priceMin": 55.1,
-      "priceAvg": 56.6,
-      "priceMax": 58.4,
-      "stationCount": 24
+      "priceMin": 51.9,
+      "priceAvg": 57.17,
+      "priceMax": 62.64,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.2,
+          "priceMax": 59.2
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.92,
+          "priceMax": 54.57
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.9,
+          "priceMax": 56.8
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.5,
+          "priceMax": 58.4
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 62.54,
+          "priceMax": 62.64
+        }
+      ]
     },
     {
-      "id": "fp-2026-01-28-krs",
-      "date": "2026-01-28",
-      "fuelType": "Kerosene",
-      "priceMin": 67.55,
-      "priceAvg": 68.85,
-      "priceMax": 70.65,
-      "stationCount": 10
+      "id": "fp-2026-02-24-dslplus",
+      "date": "2026-02-24",
+      "fuelType": "Diesel Plus",
+      "priceMin": 70.95,
+      "priceAvg": 70.95,
+      "priceMax": 70.95,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 70.95,
+          "priceMax": 70.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-10-gas91",
+      "date": "2026-02-10",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 51.95,
+      "priceAvg": 55.96,
+      "priceMax": 59.55,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.75,
+          "priceMax": 59.15
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.95,
+          "priceMax": 56.49
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.95,
+          "priceMax": 58.9
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.0,
+          "priceMax": 55.7
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 55.89,
+          "priceMax": 55.89
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.19,
+          "priceMax": 59.55
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 53.99,
+          "priceMax": 53.99
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-10-gas95",
+      "date": "2026-02-10",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 52.05,
+      "priceAvg": 57.99,
+      "priceMax": 68.5,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.75,
+          "priceMax": 60.15
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.95,
+          "priceMax": 56.99
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 52.05,
+          "priceMax": 59.9
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.0,
+          "priceMax": 56.7
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 56.39,
+          "priceMax": 56.39
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 66.1,
+          "priceMax": 68.5
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 55.99,
+          "priceMax": 55.99
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-10-dsl",
+      "date": "2026-02-10",
+      "fuelType": "Diesel",
+      "priceMin": 51.9,
+      "priceAvg": 57.0,
+      "priceMax": 61.34,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 59.55,
+          "priceMax": 61.34
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.95,
+          "priceMax": 56.39
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.9,
+          "priceMax": 57.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.4,
+          "priceMax": 58.1
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 55.39,
+          "priceMax": 55.39
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 60.84,
+          "priceMax": 61.3
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 55.5,
+          "priceMax": 55.5
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-10-dslplus",
+      "date": "2026-02-10",
+      "fuelType": "Diesel Plus",
+      "priceMin": 69.44,
+      "priceAvg": 69.99,
+      "priceMax": 70.54,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 69.44,
+          "priceMax": 70.54
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-03-gas91",
+      "date": "2026-02-03",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 51.75,
+      "priceAvg": 56.05,
+      "priceMax": 62.6,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.15,
+          "priceMax": 58.55
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.75,
+          "priceMax": 55.89
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.95,
+          "priceMax": 58.9
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.1,
+          "priceMax": 62.6
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 52.1,
+          "priceMax": 52.1
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 59.59,
+          "priceMax": 60.19
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 54.95,
+          "priceMax": 54.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-03-gas95",
+      "date": "2026-02-03",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 52.7,
+      "priceAvg": 57.78,
+      "priceMax": 68.1,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.15,
+          "priceMax": 59.55
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.95,
+          "priceMax": 56.39
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 52.7,
+          "priceMax": 59.9
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.1,
+          "priceMax": 56.4
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 54.15,
+          "priceMax": 54.15
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 67.5,
+          "priceMax": 68.1
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 56.95,
+          "priceMax": 56.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-03-dsl",
+      "date": "2026-02-03",
+      "fuelType": "Diesel",
+      "priceMin": 51.55,
+      "priceAvg": 55.95,
+      "priceMax": 61.79,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 58.55,
+          "priceMax": 60.34
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.4,
+          "priceMax": 55.39
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.55,
+          "priceMax": 53.7
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.5,
+          "priceMax": 57.1
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 52.5,
+          "priceMax": 52.5
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 61.04,
+          "priceMax": 61.79
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 54.95,
+          "priceMax": 54.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-02-03-dslplus",
+      "date": "2026-02-03",
+      "fuelType": "Diesel Plus",
+      "priceMin": 69.54,
+      "priceAvg": 69.92,
+      "priceMax": 70.29,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 69.54,
+          "priceMax": 70.29
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-27-gas91",
+      "date": "2026-01-27",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 51.9,
+      "priceAvg": 56.33,
+      "priceMax": 61.9,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 55.35,
+          "priceMax": 57.36
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.9,
+          "priceMax": 55.09
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.95,
+          "priceMax": 59.7
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 54.3,
+          "priceMax": 61.9
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 53.45,
+          "priceMax": 53.45
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.79,
+          "priceMax": 59.39
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 57.98,
+          "priceMax": 57.98
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-27-gas95",
+      "date": "2026-01-27",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 52.85,
+      "priceAvg": 57.7,
+      "priceMax": 67.3,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.35,
+          "priceMax": 58.35
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 54.0,
+          "priceMax": 55.59
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 52.85,
+          "priceMax": 61.6
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.3,
+          "priceMax": 56.8
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 54.6,
+          "priceMax": 54.6
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 66.7,
+          "priceMax": 67.3
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 56.9,
+          "priceMax": 56.9
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-27-dsl",
+      "date": "2026-01-27",
+      "fuelType": "Diesel",
+      "priceMin": 51.3,
+      "priceAvg": 55.4,
+      "priceMax": 60.19,
+      "stationCount": 7,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.95,
+          "priceMax": 57.35
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.3,
+          "priceMax": 53.79
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.65,
+          "priceMax": 58.1
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.5,
+          "priceMax": 56.9
+        },
+        {
+          "station": "SEAOIL",
+          "priceMin": 53.25,
+          "priceMax": 53.25
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 59.44,
+          "priceMax": 60.19
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 53.95,
+          "priceMax": 53.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-27-dslplus",
+      "date": "2026-01-27",
+      "fuelType": "Diesel Plus",
+      "priceMin": 67.94,
+      "priceAvg": 68.31,
+      "priceMax": 68.69,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 67.94,
+          "priceMax": 68.69
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-20-gas91",
+      "date": "2026-01-20",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 51.8,
+      "priceAvg": 56.39,
+      "priceMax": 61.4,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.9,
+          "priceMax": 56.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.8,
+          "priceMax": 55.69
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.95,
+          "priceMax": 59.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.4,
+          "priceMax": 61.4
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.09,
+          "priceMax": 58.99
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 54.98,
+          "priceMax": 54.98
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-20-gas95",
+      "date": "2026-01-20",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 53.05,
+      "priceAvg": 58.55,
+      "priceMax": 66.9,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.9,
+          "priceMax": 57.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 53.9,
+          "priceMax": 56.19
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 53.05,
+          "priceMax": 61.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.4,
+          "priceMax": 58.75
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 66.3,
+          "priceMax": 66.9
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 56.9,
+          "priceMax": 56.9
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-20-dsl",
+      "date": "2026-01-20",
+      "fuelType": "Diesel",
+      "priceMin": 50.6,
+      "priceAvg": 55.34,
+      "priceMax": 59.89,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.7,
+          "priceMax": 57.0
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 50.6,
+          "priceMax": 54.39
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 50.8,
+          "priceMax": 57.1
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 54.1,
+          "priceMax": 55.5
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.04,
+          "priceMax": 59.89
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 54.95,
+          "priceMax": 54.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-20-dslplus",
+      "date": "2026-01-20",
+      "fuelType": "Diesel Plus",
+      "priceMin": 66.54,
+      "priceAvg": 66.92,
+      "priceMax": 67.29,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 66.54,
+          "priceMax": 67.29
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-13-gas91",
+      "date": "2026-01-13",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 51.9,
+      "priceAvg": 57.08,
+      "priceMax": 60.4,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 55.9,
+          "priceMax": 59.25
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 51.9,
+          "priceMax": 54.89
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 58.65,
+          "priceMax": 58.65
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 54.4,
+          "priceMax": 60.4
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 57.09,
+          "priceMax": 59.64
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-13-gas95",
+      "date": "2026-01-13",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 52.9,
+      "priceAvg": 59.52,
+      "priceMax": 67.75,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 56.9,
+          "priceMax": 60.25
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.9,
+          "priceMax": 55.39
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 60.55,
+          "priceMax": 60.55
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.4,
+          "priceMax": 57.75
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 67.75,
+          "priceMax": 67.75
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-13-dsl",
+      "date": "2026-01-13",
+      "fuelType": "Diesel",
+      "priceMin": 50.1,
+      "priceAvg": 55.39,
+      "priceMax": 59.19,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 54.7,
+          "priceMax": 58.75
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 50.1,
+          "priceMax": 52.95
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 55.6,
+          "priceMax": 55.6
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 53.35,
+          "priceMax": 55.45
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.19,
+          "priceMax": 59.19
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-13-dslplus",
+      "date": "2026-01-13",
+      "fuelType": "Diesel Plus",
+      "priceMin": 66.64,
+      "priceAvg": 66.64,
+      "priceMax": 66.64,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 66.64,
+          "priceMax": 66.64
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-06-gas91",
+      "date": "2026-01-06",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 52.1,
+      "priceAvg": 56.06,
+      "priceMax": 60.95,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.8,
+          "priceMax": 58.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.1,
+          "priceMax": 54.59
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 52.5,
+          "priceMax": 58.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 54.1,
+          "priceMax": 56.45
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.84,
+          "priceMax": 60.95
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 53.98,
+          "priceMax": 53.98
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-06-gas95",
+      "date": "2026-01-06",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 52.6,
+      "priceAvg": 58.09,
+      "priceMax": 67.45,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 58.8,
+          "priceMax": 59.95
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.6,
+          "priceMax": 55.09
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 53.15,
+          "priceMax": 59.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.1,
+          "priceMax": 57.45
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 66.75,
+          "priceMax": 67.45
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 55.9,
+          "priceMax": 55.9
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-06-dsl",
+      "date": "2026-01-06",
+      "fuelType": "Diesel",
+      "priceMin": 50.1,
+      "priceAvg": 54.77,
+      "priceMax": 59.49,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 55.6,
+          "priceMax": 58.55
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 50.1,
+          "priceMax": 52.75
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.0,
+          "priceMax": 57.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 53.15,
+          "priceMax": 55.25
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 58.04,
+          "priceMax": 59.49
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 52.95,
+          "priceMax": 52.95
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-01-06-dslplus",
+      "date": "2026-01-06",
+      "fuelType": "Diesel Plus",
+      "priceMin": 66.44,
+      "priceAvg": 66.49,
+      "priceMax": 66.54,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 66.44,
+          "priceMax": 66.54
+        }
+      ]
+    },
+    {
+      "id": "fp-2025-12-30-gas91",
+      "date": "2025-12-30",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 52.25,
+      "priceAvg": 57.1,
+      "priceMax": 62.52,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 57.9,
+          "priceMax": 59.05
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 52.25,
+          "priceMax": 54.69
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 52.45,
+          "priceMax": 59.5
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 55.85,
+          "priceMax": 60.2
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 60.99,
+          "priceMax": 62.52
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 54.9,
+          "priceMax": 54.9
+        }
+      ]
+    },
+    {
+      "id": "fp-2025-12-30-gas95",
+      "date": "2025-12-30",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 53.25,
+      "priceAvg": 59.1,
+      "priceMax": 69.25,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 58.9,
+          "priceMax": 60.05
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 53.95,
+          "priceMax": 55.19
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 53.25,
+          "priceMax": 60.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 56.85,
+          "priceMax": 61.2
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 68.8,
+          "priceMax": 69.25
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 55.9,
+          "priceMax": 55.9
+        }
+      ]
+    },
+    {
+      "id": "fp-2025-12-30-dsl",
+      "date": "2025-12-30",
+      "fuelType": "Diesel",
+      "priceMin": 50.1,
+      "priceAvg": 55.48,
+      "priceMax": 60.55,
+      "stationCount": 6,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 55.4,
+          "priceMax": 58.35
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 50.1,
+          "priceMax": 53.05
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 51.9,
+          "priceMax": 59.0
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 54.5,
+          "priceMax": 55.05
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 59.6,
+          "priceMax": 60.55
+        },
+        {
+          "station": "TOTAL",
+          "priceMin": 54.1,
+          "priceMax": 54.1
+        }
+      ]
+    },
+    {
+      "id": "fp-2025-12-30-dslplus",
+      "date": "2025-12-30",
+      "fuelType": "Diesel Plus",
+      "priceMin": 66.2,
+      "priceAvg": 67.15,
+      "priceMax": 68.1,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 66.2,
+          "priceMax": 68.1
+        }
+      ]
     }
   ],
   "filters": {
     "fuelTypes": [
       "Gasoline RON 91",
       "Gasoline RON 95",
-      "Gasoline RON 97",
       "Diesel",
-      "Kerosene"
+      "Diesel Plus"
     ],
     "weeks": [
-      "2026-04-15",
-      "2026-04-08",
-      "2026-04-01",
-      "2026-03-25",
-      "2026-03-18",
-      "2026-03-11",
-      "2026-03-04",
-      "2026-02-25",
-      "2026-02-18",
-      "2026-02-11",
-      "2026-02-04",
-      "2026-01-28"
+      "2026-04-14",
+      "2026-04-07",
+      "2026-03-31",
+      "2026-03-24",
+      "2026-03-17",
+      "2026-03-10",
+      "2026-03-03",
+      "2026-02-24",
+      "2026-02-10",
+      "2026-02-03",
+      "2026-01-27",
+      "2026-01-20",
+      "2026-01-13",
+      "2026-01-06",
+      "2025-12-30"
+    ],
+    "brands": [
+      "CALTEX",
+      "FLYING V",
+      "INDEPENDENT",
+      "PETRON",
+      "SEAOIL",
+      "SHELL",
+      "TOTAL"
     ]
   },
   "stats": {
-    "latestWeek": "2026-04-15",
-    "weeksTracked": 12,
-    "fuelTypes": 5,
-    "stationsSurveyed": 28
+    "latestWeek": "2026-04-14",
+    "weeksTracked": 15,
+    "fuelTypes": 4,
+    "stationsSurveyed": 7
   },
   "source": "DOE Oil Industry Management Bureau",
   "sourceUrl": "https://www.doe.gov.ph/oil-monitor",
   "contributor": "Shiro_Oni",
-  "lastUpdated": "2026-04-15"
+  "lastUpdated": "2026-04-14"
 }

--- a/src/pages/Transparency.tsx
+++ b/src/pages/Transparency.tsx
@@ -6,12 +6,14 @@ import {
   FileSearch,
   FileText,
   FolderOpen,
+  Fuel,
   ShoppingCart,
   TrendingUp,
 } from 'lucide-react';
 import { useState } from 'react';
 import SEO from '../components/SEO';
 import FloodControlSection from '../components/transparency/FloodControlSection';
+import FuelPricesSection from '../components/transparency/FuelPricesSection';
 import { Card, CardContent } from '../components/ui/Card';
 import { Heading } from '../components/ui/Heading';
 import Section from '../components/ui/Section';
@@ -24,6 +26,12 @@ const categories = [
     name: 'Flood Control Projects',
     icon: Droplets,
     description: '39 DPWH flood control projects in Bacolod City',
+  },
+  {
+    slug: 'fuel-prices',
+    name: 'Fuel Price Watch',
+    icon: Fuel,
+    description: 'Weekly DOE retail fuel prices in Bacolod City',
   },
   {
     slug: 'reports',
@@ -48,6 +56,7 @@ const Transparency: React.FC = () => {
 
   const renderContent = () => {
     if (activeSection === 'flood-control') return <FloodControlSection />;
+    if (activeSection === 'fuel-prices') return <FuelPricesSection />;
     if (activeSection === 'infrastructure') return <InfrastructureSection />;
     if (activeSection === 'reports') return <ReportsSection />;
     return null;
@@ -57,8 +66,8 @@ const Transparency: React.FC = () => {
     <>
       <SEO
         title="Transparency"
-        description="Government transparency data for Bacolod City - flood control projects, infrastructure, procurement, and public reports."
-        keywords="transparency, flood control, infrastructure, procurement, Bacolod City, DPWH"
+        description="Government transparency data for Bacolod City - flood control projects, fuel prices, infrastructure, procurement, and public reports."
+        keywords="transparency, flood control, fuel prices, gas prices, diesel, DOE, infrastructure, procurement, Bacolod City, DPWH"
       />
       <Section className="min-h-[60vh]">
         <div className="text-center mb-6 md:mb-10">
@@ -108,7 +117,7 @@ const Transparency: React.FC = () => {
 
         {/* Desktop: Card Grid + Content Below */}
         <div className="hidden lg:block">
-          <div className="grid grid-cols-3 gap-6">
+          <div className="grid grid-cols-2 xl:grid-cols-4 gap-6">
             {categories.map((cat) => {
               const Icon = cat.icon;
               const isActive = activeSection === cat.slug;


### PR DESCRIPTION
## Summary
- Adds a **Fuel Price Watch** tile to `/transparency` showing weekly DOE retail fuel prices for Bacolod City
- Follows the existing Flood Control pattern: stats row, recharts line + bar charts, fuel-type/week filters, snapshot table, DOE attribution
- Credits @Shiro_Oni for extracting the DOE dataset

## Status: pending real fuel data JSON
- `src/data/transparency/fuel-prices.json` currently ships with **placeholder figures** (flagged by `"placeholder": true` and an amber in-UI banner)
- Merge-blocked on Shiro_Oni's CSV/XLSX export from the Power BI report; swap-in will be a single-file PR

## Out of scope (phase 2)
- Station map (needs per-station coords + map library)
- Weekly auto-update pipeline

## Test plan
- [ ] `bun run dev` → `/transparency` → click **Fuel Price Watch** tile on both mobile and desktop
- [ ] Fuel-type and week filters update the table reactively
- [ ] `bun run build` passes with no new warnings
- [ ] Homepage search for "fuel" / "gas" / "diesel" returns the Fuel Price Watch entry
- [ ] Responsive at 375px, 768px, 1280px
- [ ] Keyboard + screen-reader pass (selects have `aria-label`, table has `scope="col"`, direction glyphs are `aria-hidden` with sr-only text)