### PR TITLE
ci: fix release-please tag format to plain v1.x.y

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",
       "package-name": "betterbacolod",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Why
release-please default config with \`packages: { \".\": ... }\` prepended the component name to tags (\`betterbacolod-v1.1.0\`) and compared against that on next run. Since our existing release tag is plain \`v1.0.0\`, release-please couldn't recognize it as a prior release — so the v1.1.0 changelog included every commit since the project started, not just since v1.0.0.

## Fix
Add \`include-component-in-tag: false\` so future releases use plain \`vX.Y.Z\` tags matching the existing \`v1.0.0\` baseline.

## Effect
- Next release PR's CHANGELOG will only include commits since \`v1.1.0\`
- No schema change; no action needed on the v1.1.0 release we just shipped