### PR TITLE
content(fuel-prices): update DOE data for week of April 21–27, 2026

### DIFF
--- a/src/data/transparency/fuel-prices.json
+++ b/src/data/transparency/fuel-prices.json
@@ -2,6 +2,130 @@
   "placeholder": false,
   "snapshots": [
     {
+      "id": "fp-2026-04-21-gas91",
+      "date": "2026-04-21",
+      "fuelType": "Gasoline RON 91",
+      "priceMin": 78.5,
+      "priceAvg": 82.58,
+      "priceMax": 89.7,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 80.0,
+          "priceMax": 83.0
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 79.0,
+          "priceMax": 89.7
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 78.5,
+          "priceMax": 86.1
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 80.0,
+          "priceMax": 80.1
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 83.3,
+          "priceMax": 86.1
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-04-21-gas95",
+      "date": "2026-04-21",
+      "fuelType": "Gasoline RON 95",
+      "priceMin": 79.0,
+      "priceAvg": 84.39,
+      "priceMax": 90.1,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 82.0,
+          "priceMax": 88.0
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 80.0,
+          "priceMax": 85.7
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 79.0,
+          "priceMax": 86.4
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 81.0,
+          "priceMax": 81.6
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 90.1,
+          "priceMax": 90.1
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-04-21-dsl",
+      "date": "2026-04-21",
+      "fuelType": "Diesel",
+      "priceMin": 79.0,
+      "priceAvg": 91.81,
+      "priceMax": 100.3,
+      "stationCount": 5,
+      "byStation": [
+        {
+          "station": "CALTEX",
+          "priceMin": 91.8,
+          "priceMax": 93.0
+        },
+        {
+          "station": "FLYING V",
+          "priceMin": 79.0,
+          "priceMax": 100.3
+        },
+        {
+          "station": "INDEPENDENT",
+          "priceMin": 90.0,
+          "priceMax": 97.95
+        },
+        {
+          "station": "PETRON",
+          "priceMin": 90.3,
+          "priceMax": 90.7
+        },
+        {
+          "station": "SHELL",
+          "priceMin": 92.5,
+          "priceMax": 92.6
+        }
+      ]
+    },
+    {
+      "id": "fp-2026-04-21-dslplus",
+      "date": "2026-04-21",
+      "fuelType": "Diesel Plus",
+      "priceMin": 106.2,
+      "priceAvg": 106.2,
+      "priceMax": 106.2,
+      "stationCount": 1,
+      "byStation": [
+        {
+          "station": "SHELL",
+          "priceMin": 106.2,
+          "priceMax": 106.2
+        }
+      ]
+    },
+    {
       "id": "fp-2026-04-14-gas91",
       "date": "2026-04-14",
       "fuelType": "Gasoline RON 91",
@@ -2159,6 +2283,7 @@
       "Diesel Plus"
     ],
     "weeks": [
+      "2026-04-21",
       "2026-04-14",
       "2026-04-07",
       "2026-03-31",
@@ -2175,24 +2300,16 @@
       "2026-01-06",
       "2025-12-30"
     ],
-    "brands": [
-      "CALTEX",
-      "FLYING V",
-      "INDEPENDENT",
-      "PETRON",
-      "SEAOIL",
-      "SHELL",
-      "TOTAL"
-    ]
+    "brands": ["CALTEX", "FLYING V", "INDEPENDENT", "PETRON", "SHELL"]
   },
   "stats": {
-    "latestWeek": "2026-04-14",
-    "weeksTracked": 15,
+    "latestWeek": "2026-04-21",
+    "weeksTracked": 16,
     "fuelTypes": 4,
-    "stationsSurveyed": 7
+    "stationsSurveyed": 5
   },
   "source": "DOE Oil Industry Management Bureau",
   "sourceUrl": "https://www.doe.gov.ph/oil-monitor",
   "contributor": "Shiro_Oni",
-  "lastUpdated": "2026-04-14"
+  "lastUpdated": "2026-04-21"
 }


### PR DESCRIPTION
## Summary
Adds the week of **April 21–27, 2026** to \`src/data/transparency/fuel-prices.json\`. JSON now covers **16 weeks** (2025-12-30 → 2026-04-21).

## Notable: prices dropped sharply this week

| Fuel | Last week (Apr 14) | This week (Apr 21) | Change |
|---|---|---|---|
| Regular unleaded (RON 91) | ₱82.40 – ₱105.20 (avg ₱87.94) | **₱78.50 – ₱89.70 (avg ₱82.58)** | ▼ ₱5.36 avg |
| Premium (RON 95) | ₱84.40 – ₱109.00 (avg ₱90.75) | **₱79.00 – ₱90.10 (avg ₱84.39)** | ▼ ₱6.36 avg |
| Diesel | ₱114.10 – ₱152.90 (avg ₱119.61) | **₱79.00 – ₱100.30 (avg ₱91.81)** | ▼ ₱27.80 avg |
| Diesel Plus | ₱131.20 – ₱161.10 (avg ₱146.15) | **₱106.20 (avg ₱106.20)** | ▼ ₱39.95 avg |

Diesel dropped ~₱28 in a week — significant correction. Worth flagging in the FB launch post when you cross-post.

## Brands reporting
This week 5 brands reported: **CALTEX, FLYING V, INDEPENDENT, PETRON, SHELL**.
SEAOIL, TOTAL, JETTI did not submit prices for this week — UI will reflect "5 brands surveyed" for the latest week.

## Note for next week
This week's data was patched into the JSON manually because it came from a screenshot mid-week. For future updates, ideally the source XLSX (\`~/Downloads/BacolodFuelPrices/BacolodFuelPrices.xlsx\`) gets refreshed by Shiro_Oni and we run \`python3 scripts/import-fuel-prices.py …\` for a clean regeneration.

## Test plan
- [x] \`bun run check\` clean
- [x] \`bun run build\` green
- [ ] Eyeball /transparency → Fuel Price Watch shows "April 21–27, 2026" in the header
- [ ] Trend chart renders the new data point
- [ ] Brand-list expansion shows 5 brands for the new week